### PR TITLE
FIX: drop eventlistner when in dev mode

### DIFF
--- a/io-pay-portal-fe/src/routes/PaymentResponsePage.tsx
+++ b/io-pay-portal-fe/src/routes/PaymentResponsePage.tsx
@@ -64,9 +64,7 @@ export default function PaymentCheckPage() {
         idStatus,
         outcome,
       });
-      if (isDirectAcquirer !== undefined) {
-        showFinalResult(outcome);
-      }
+      showFinalResult(outcome);
     };
 
     const showFinalResult = (outcome: OutcomeEnumType) => {

--- a/io-pay-portal-fe/src/utils/api/response.ts
+++ b/io-pay-portal-fe/src/utils/api/response.ts
@@ -118,6 +118,9 @@ export const callServices = async (
   window.addEventListener(
     "message",
     async function (e) {
+      if((/^react-devtools/gi).test(e.data.source)) {
+        return;
+        }
       fromPredicate<Error, MessageEvent<any>>(
         // Addresses must be static
         (e1) =>


### PR DESCRIPTION
The event listner called "message" useful to listen the 3DS iframe is used also by React in dev mode....
we need to exclude this case from our business logic

#### List of Changes

- Drop listener when "react-devtools-bridge" is setted as origin

#### Motivation and Context

The event listner called "message" useful to listen the 3DS iframe is used also by React in dev mode....
we need to exclude this case from our business logic
