### PR TITLE
Fix detail instead detail_v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "generate": "npm-run-all generate:*",
     "generate:payment-transactions-api": "rimraf generated/definitions/payment-transactions-api && shx mkdir -p generated/definitions/payment-transactions-api && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/pagopa-functions-checkout/v1.1.2/openapi/index.yaml --no-strict --out-dir ./generated/definitions/payment-transactions-api --request-types --response-decoders --client",
     "generate:payment-manager-api": "rimraf generated/definitions/payment-manager-api && shx mkdir -p generated/definitions/payment-manager-api && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-pay/master/openapi/api.yml --no-strict --out-dir ./generated/definitions/payment-manager-api --request-types --response-decoders --client",
-    "generate:payment-activations-api": "rimraf generated/definitions/payment-activations-api && shx mkdir -p generated/definitions/payment-activations-api && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-pagopa-proxy/v1.1.4/api-spec/api-for-checkout.yaml --no-strict --out-dir ./generated/definitions/payment-activations-api --request-types --response-decoders --client",
+    "generate:payment-activations-api": "rimraf generated/definitions/payment-activations-api && shx mkdir -p generated/definitions/payment-activations-api && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-pagopa-proxy/v1.1.5/api-spec/api-for-checkout.yaml --no-strict --out-dir ./generated/definitions/payment-activations-api --request-types --response-decoders --client",
     "lint": "eslint . -c .eslintrc.js --ext .ts,.tsx",
     "lint-autofix": "eslint . -c .eslintrc.js --ext .ts,.tsx --fix",
     "prebuild": "npm-run-all generate type-check lint",

--- a/src/utils/api/helper.ts
+++ b/src/utils/api/helper.ts
@@ -9,10 +9,7 @@ import { CodiceContestoPagamento } from "../../../generated/definitions/payment-
 import { ImportoEuroCents } from "../../../generated/definitions/payment-activations-api/ImportoEuroCents";
 import { PaymentActivationsGetResponse } from "../../../generated/definitions/payment-activations-api/PaymentActivationsGetResponse";
 import { PaymentActivationsPostResponse } from "../../../generated/definitions/payment-activations-api/PaymentActivationsPostResponse";
-import {
-  Detail_v2Enum,
-  PaymentProblemJson,
-} from "../../../generated/definitions/payment-activations-api/PaymentProblemJson";
+import { Detail_v2Enum } from "../../../generated/definitions/payment-activations-api/PaymentProblemJson";
 import { PaymentRequestsGetResponse } from "../../../generated/definitions/payment-activations-api/PaymentRequestsGetResponse";
 import {
   TypeEnum,
@@ -142,9 +139,7 @@ export const getPaymentInfoTask = (
               if (responseType.status === 400) {
                 return TE.left(
                   pipe(
-                    O.fromNullable(
-                      (responseType.value as PaymentProblemJson)?.detail_v2
-                    ),
+                    O.fromNullable(responseType.value?.detail as Detail_v2Enum),
                     O.getOrElse(() => Detail_v2Enum.GENERIC_ERROR)
                   )
                 );
@@ -215,9 +210,7 @@ export const activePaymentTask = (
               if (responseType.status === 400) {
                 return TE.left(
                   pipe(
-                    O.fromNullable(
-                      (responseType.value as PaymentProblemJson)?.detail_v2
-                    ),
+                    O.fromNullable(responseType.value?.detail as Detail_v2Enum),
                     O.getOrElse(() => ErrorsType.STATUS_ERROR as string)
                   )
                 );


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- use detail instead detail_v2 in payment activations error

#### Motivation and Context

The goal of this PR is to restore the `detail` instead of `detail_v2` waintg for https://pagopa.atlassian.net/browse/IOPAY-594

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
