### PR TITLE
[CHK-323] Manual prod approval after prod build

### DIFF
--- a/.devops/pagopa-deploy-pipelines.yml
+++ b/.devops/pagopa-deploy-pipelines.yml
@@ -268,25 +268,11 @@ stages:
               scriptLocation: inlineScript
               inlineScript: |
                 call az cdn endpoint purge -g pagopa-u-checkout-fe-rg -n pagopa-u-checkout-cdn-endpoint --profile-name pagopa-u-checkout-cdn-profile --content-paths "/*"
-
-  - stage: UAT_to_PROD_promotion
-    dependsOn:
-      - Deploy_UAT_pagoPA
-    jobs:
-      - job: Deploy_Prod_WaitForApproval
-        displayName: Wait for PROD approval
-        pool: server
-        timeoutInMinutes: 4320 # 3 days
-        steps:
-        - task: ManualValidation@0
-          timeoutInMinutes: 4320 # 3 days
-          inputs:
-            onTimeout: 'skip'
  
     # Prepare Artifact
   - stage: Prepare_artifact_prod
     dependsOn:
-      - UAT_to_PROD_promotion
+      - Deploy_UAT_pagoPA
     jobs:
       - job: make_build
         steps:
@@ -319,6 +305,20 @@ stages:
 
           - publish: $(System.DefaultWorkingDirectory)/dist
             artifact: Bundle
+
+  - stage: UAT_to_PROD_promotion
+    dependsOn:
+      - Prepare_artifact_prod
+    jobs:
+      - job: Deploy_Prod_WaitForApproval
+        displayName: Wait for PROD approval
+        pool: server
+        timeoutInMinutes: 4320 # 3 days
+        steps:
+        - task: ManualValidation@0
+          timeoutInMinutes: 4320 # 3 days
+          inputs:
+            onTimeout: 'skip'
 
   - stage: Deploy_PROD_pagoPA
     dependsOn:


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- move manual prod approval after prod build

#### Motivation and Context

The goal of this PR is to reduce the time between approval and actual deployment by moving the build step to prod first.

#### How Has This Been Tested?

Check next deploy in prod :-)

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
