### PR TITLE
[#CHK-43] Tap the whole div to show amount on mobile

### DIFF
--- a/src/components/commons/Header.tsx
+++ b/src/components/commons/Header.tsx
@@ -91,15 +91,12 @@ export default function Header() {
                 display="flex"
                 alignItems="center"
                 justifyContent="flex-end"
+                onClick={toggleDrawer(true)}
               >
                 {PaymentCheckData
                   ? moneyFormat(PaymentCheckData.amount.amount)
                   : ""}
-                <InfoOutlinedIcon
-                  color="primary"
-                  sx={{ ml: 1 }}
-                  onClick={toggleDrawer(true)}
-                />
+                <InfoOutlinedIcon color="primary" sx={{ ml: 1 }} />
               </Typography>
             </Grid>
             <DrawerDetail


### PR DESCRIPTION
This PR make "tappable" the whole div on header (when in mobile breakpoint)

#### List of Changes

- slice the event on the parent div instead the "info" image

#### Motivation and Context

- Better UX

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
