### PR TITLE
Fix long payment detail text

### DIFF
--- a/src/components/Header/DrawerDetail.tsx
+++ b/src/components/Header/DrawerDetail.tsx
@@ -78,7 +78,12 @@ export default function DrawerDetail(props: Props) {
             >
               {t("mainPage.header.detail.detailSubject")}
             </Typography>
-            <Typography variant="body2" fontWeight={600} component="div">
+            <Typography
+              variant="body2"
+              fontWeight={600}
+              component="div"
+              sx={{ overflowWrap: "anywhere" }}
+            >
               {props.PaymentInfo.subject}
             </Typography>
             <Typography

--- a/src/components/Header/DrawerDetail.tsx
+++ b/src/components/Header/DrawerDetail.tsx
@@ -82,7 +82,7 @@ export default function DrawerDetail(props: Props) {
               variant="body2"
               fontWeight={600}
               component="div"
-              sx={{ overflowWrap: "anywhere" }}
+              sx={{ wordBreak: "break-word" }}
             >
               {props.PaymentInfo.subject}
             </Typography>

--- a/src/components/TextFormField/FieldContainer.tsx
+++ b/src/components/TextFormField/FieldContainer.tsx
@@ -66,7 +66,11 @@ function FieldContainer(props: {
               t(props.title)
             )}
           </Typography>
-          <Typography variant={props.bodyVariant} component={"div"}>
+          <Typography
+            variant={props.bodyVariant}
+            component={"div"}
+            sx={{ overflowWrap: "anywhere" }}
+          >
             {props.loading ? (
               <Skeleton variant="text" width="188px" height="24px" />
             ) : (

--- a/src/components/TextFormField/FieldContainer.tsx
+++ b/src/components/TextFormField/FieldContainer.tsx
@@ -69,7 +69,7 @@ function FieldContainer(props: {
           <Typography
             variant={props.bodyVariant}
             component={"div"}
-            sx={{ overflowWrap: "anywhere" }}
+            sx={{ wordBreak: "break-word" }}
           >
             {props.loading ? (
               <Skeleton variant="text" width="188px" height="24px" />

--- a/src/components/commons/Header.tsx
+++ b/src/components/commons/Header.tsx
@@ -68,7 +68,7 @@ export default function Header() {
                 fontWeight={600}
                 variant="body2"
                 component="div"
-                sx={{ textAlign: "center", overflowWrap: "anywhere" }}
+                sx={{ textAlign: "center", wordBreak: "break-word" }}
               >
                 {PaymentInfo.subject.length > 140
                   ? PaymentInfo.subject.substring(0, 140)

--- a/src/components/commons/Header.tsx
+++ b/src/components/commons/Header.tsx
@@ -28,6 +28,7 @@ export default function Header() {
     CheckoutRoutes.ANNULLATO,
     CheckoutRoutes.ERRORE,
     CheckoutRoutes.ESITO,
+    CheckoutRoutes.DONA,
   ];
   const toggleDrawer =
     (open: boolean) => (event: React.KeyboardEvent | React.MouseEvent) => {
@@ -67,9 +68,11 @@ export default function Header() {
                 fontWeight={600}
                 variant="body2"
                 component="div"
-                sx={{ textAlign: "center" }}
+                sx={{ textAlign: "center", overflowWrap: "anywhere" }}
               >
-                {PaymentInfo.subject}
+                {PaymentInfo.subject.length > 140
+                  ? PaymentInfo.subject.substring(0, 140)
+                  : PaymentInfo.subject}
               </Typography>
               <Typography
                 color="primary.main"


### PR DESCRIPTION
This PR fixes long payment info text not wrapping accordingly in the header, header drawer and payment summary page, causing bad view on mobile/small devices. 

#### List of Changes

Fix long payment info text
Added "/dona" as ignored path for header view

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
