### PR TITLE
[#CHK-719] Drop fiscalCode from POST to start-session

### DIFF
--- a/src/utils/api/helper.ts
+++ b/src/utils/api/helper.ts
@@ -647,10 +647,7 @@ export const getSessionWallet = async (
                 O.fromNullable(checkData.idPayment),
                 O.getOrElse(() => "")
               ),
-              fiscalCode: pipe(
-                O.fromNullable(checkData.fiscalCode),
-                O.getOrElse(() => "")
-              ),
+              fiscalCode: "", // always empty cfr CHK-719
             },
           },
         }),

--- a/src/utils/api/helper.ts
+++ b/src/utils/api/helper.ts
@@ -646,8 +646,7 @@ export const getSessionWallet = async (
               idPayment: pipe(
                 O.fromNullable(checkData.idPayment),
                 O.getOrElse(() => "")
-              ),
-              fiscalCode: "", // always empty cfr CHK-719
+              )
             },
           },
         }),


### PR DESCRIPTION
This PR drop fiscalCode to start-session call

#### List of Changes

- Putting an empty string to helper when call startSessionUsingPOST

#### Motivation and Context

- In admin-panel we've not to list fiscal-code of user


#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
