### PR TITLE
[#CHK-833] Return url in case of KO

### DIFF
--- a/src/routes/PaymentResponsePage.tsx
+++ b/src/routes/PaymentResponsePage.tsx
@@ -41,7 +41,9 @@ type printData = {
 export default function PaymentCheckPage() {
   const [loading, setLoading] = useState(true);
   const [outcomeMessage, setOutcomeMessage] = useState<responseMessage>();
-  const redirectUrl = getReturnUrls().returnOkUrl;
+  const [redirectUrl, setRedirectUrl] = useState<string>(
+    getReturnUrls().returnOkUrl
+  );
   const PaymentCheckData = getCheckData() as PaymentCheckData;
   const wallet = getWallet();
   const email = getEmailInfo();
@@ -77,7 +79,12 @@ export default function PaymentCheckPage() {
         E.getOrElse(() => ViewOutcomeEnum.GENERIC_ERROR as ViewOutcomeEnum)
       );
       const message = responseOutcome[viewOutcome];
+      const redirectTo =
+        viewOutcome === "0"
+          ? getReturnUrls().returnOkUrl
+          : getReturnUrls().returnErrorUrl;
       setOutcomeMessage(message);
+      setRedirectUrl(redirectTo);
       setLoading(false);
       window.removeEventListener("beforeunload", onBrowserUnload);
       clearSensitiveItems();

--- a/src/routes/PaymentSummaryPage.tsx
+++ b/src/routes/PaymentSummaryPage.tsx
@@ -77,10 +77,10 @@ export default function PaymentSummaryPage() {
           sx={{ px: 2 }}
         />
       )}
-      {!!paymentInfo.paName && (
+      {!!paymentInfo.paFiscalCode && (
         <FieldContainer
           title="paymentSummaryPage.cf"
-          body={paymentInfo.paName}
+          body={paymentInfo.paFiscalCode}
           flexDirection="row"
           overflowWrapBody={false}
           sx={{ px: 2 }}

--- a/src/utils/api/apiService.ts
+++ b/src/utils/api/apiService.ts
@@ -135,9 +135,9 @@ export function getReturnUrls(): ReturnUrls {
     | ReturnUrls
     | undefined;
   return {
-    returnOkUrl: data?.returnOkUrl || "",
-    returnErrorUrl: data?.returnErrorUrl || "",
-    returnCancelUrl: data?.returnCancelUrl || "",
+    returnOkUrl: data?.returnOkUrl || "/",
+    returnErrorUrl: data?.returnErrorUrl || "/",
+    returnCancelUrl: data?.returnCancelUrl || "/",
   };
 }
 

--- a/src/utils/api/helper.ts
+++ b/src/utils/api/helper.ts
@@ -605,21 +605,14 @@ export const getPaymentCheckData = async ({
                             EVENT_ID: PAYMENT_CHECK_SUCCESS.value,
                           });
 
-                          const originInput = pipe(
-                            O.fromNullable(response.value.data.origin),
-                            O.getOrElse(() => response.value.data.urlRedirectEc)
-                          );
                           const cart = getCart();
                           setReturnUrls(
                             cart?.returnUrls.returnOkUrl
                               ? cart.returnUrls
                               : {
-                                  returnOkUrl:
-                                    originInput === "payportal"
-                                      ? "/"
-                                      : response.value.data.urlRedirectEc,
-                                  returnCancelUrl: "",
-                                  returnErrorUrl: "",
+                                  returnOkUrl: "/",
+                                  returnCancelUrl: "/",
+                                  returnErrorUrl: "/",
                                 }
                           );
                         })


### PR DESCRIPTION
When a payment flow returns KO, we have to expose the correct url to the "close button"

#### List of Changes
- Fix manage of KOurl considering idStatus
- fix payportal origin dropping unusefful condition
- fix cf name in summary


#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
