### PR TITLE
[#CHK-994] amount limit to show disclaimer set on 0

### DIFF
--- a/src/routes/PaymentCheckPage.tsx
+++ b/src/routes/PaymentCheckPage.tsx
@@ -327,7 +327,7 @@ export default function PaymentCheckPage() {
 
 const AmountDisclaimer = ({ amount }: { amount: number }) => {
   const { t } = useTranslation();
-  const disclaimerUpperLimit = 50;
+  const disclaimerUpperLimit = 0;
   const disclaimer =
     amount < disclaimerUpperLimit
       ? t("paymentCheckPage.disclaimer.cheaper")


### PR DESCRIPTION
This PR set on "0" the amount limit to show disclaimer at the bottom of PSP's commission  

#### List of Changes

- Set 0 on `disclaimerUpperLimit` 

#### Motivation and Context

Silent mode, for now

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
