### PR TITLE
Fix polling trasaction status

### DIFF
--- a/src/utils/__tests__/TransactionResultUtil.test.ts
+++ b/src/utils/__tests__/TransactionResultUtil.test.ts
@@ -30,7 +30,7 @@ describe("TransactionResultUtil", () => {
       getViewOutcomeFromEcommerceResultCode(
         TransactionStatusEnum.AUTHORIZATION_FAILED
       )
-    ).toEqual(ViewOutcomeEnum.GENERIC_ERROR);
+    ).toEqual(ViewOutcomeEnum.AUTH_ERROR);
 
     expect(
       getViewOutcomeFromEcommerceResultCode(

--- a/src/utils/transactions/TransactionResultUtil.ts
+++ b/src/utils/transactions/TransactionResultUtil.ts
@@ -15,6 +15,9 @@ export enum ViewOutcomeEnum {
 
 export enum EcommerceFinalStatusCodeEnum {
   NOTIFIED,
+  AUTHORIZATION_FAILED,
+  CLOSURE_FAILED,
+  NOTIFIED_FAILED,
 }
 
 export const getViewOutcomeFromEcommerceResultCode = (
@@ -23,6 +26,8 @@ export const getViewOutcomeFromEcommerceResultCode = (
   switch (ecommerceStatus) {
     case TransactionStatusEnum.NOTIFIED:
       return ViewOutcomeEnum.SUCCESS;
+    case TransactionStatusEnum.AUTHORIZATION_FAILED:
+      return ViewOutcomeEnum.AUTH_ERROR;
     default:
       return ViewOutcomeEnum.GENERIC_ERROR;
   }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Managed three new states to stop polling on the get transaction for the outcome page
<!--- Describe your changes in detail -->
Three new transaction states have been managed that allow polling  stop. 

1. AUTHORIZATION_FAILED
2. CLOSURE_FAILED 
3. NOTIFIED_FAILED

AUTHORIZATION_FAILED status ends the authorization denied page
#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
The tests were performed locally
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
