### PR TITLE
[#CHK-1111] Drop returnUrls from SessionStorage

### DIFF
--- a/src/features/payment/models/paymentModel.ts
+++ b/src/features/payment/models/paymentModel.ts
@@ -172,7 +172,7 @@ export interface PaymentNotice {
   description?: string;
 }
 
-export interface ReturnUrls {
+interface ReturnUrls {
   returnOkUrl: string;
   returnCancelUrl: string;
   returnErrorUrl: string;

--- a/src/routes/CancelledPage.tsx
+++ b/src/routes/CancelledPage.tsx
@@ -3,13 +3,13 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import cancelled from "../assets/images/response-unrecognized.svg";
 import PageContainer from "../components/PageContent/PageContainer";
+import { Cart } from "../features/payment/models/paymentModel";
 import { useAppDispatch } from "../redux/hooks/hooks";
-import { ReturnUrls } from "../features/payment/models/paymentModel";
 import { resetCardData } from "../redux/slices/cardData";
 import { resetSecurityCode } from "../redux/slices/securityCode";
 import { onBrowserUnload } from "../utils/eventListeners";
 import {
-  clearSensitiveItems,
+  clearStorage,
   getSessionItem,
   SessionItems,
 } from "../utils/storage/sessionStorage";
@@ -18,14 +18,14 @@ export default function CancelledPage() {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
   const redirectUrl =
-    (getSessionItem(SessionItems.returnUrls) as ReturnUrls | undefined)
-      ?.returnCancelUrl || "/";
+    (getSessionItem(SessionItems.cart) as Cart | undefined)?.returnUrls
+      .returnCancelUrl || "/";
 
   React.useEffect(() => {
     dispatch(resetSecurityCode());
     dispatch(resetCardData());
     window.removeEventListener("beforeunload", onBrowserUnload);
-    clearSensitiveItems();
+    clearStorage();
   }, []);
 
   return (
@@ -51,7 +51,6 @@ export default function CancelledPage() {
             type="button"
             variant="outlined"
             onClick={() => {
-              sessionStorage.clear();
               window.location.replace(redirectUrl);
             }}
             style={{

--- a/src/routes/IndexPage.tsx
+++ b/src/routes/IndexPage.tsx
@@ -5,6 +5,7 @@ import { PaymentNoticeChoice } from "../features/payment/components/PaymentNotic
 import { useAppDispatch } from "../redux/hooks/hooks";
 import { resetSecurityCode } from "../redux/slices/securityCode";
 import { resetCardData } from "../redux/slices/cardData";
+import { clearStorage } from "../utils/storage/sessionStorage";
 
 export default function IndexPage() {
   const dispatch = useAppDispatch();
@@ -13,7 +14,7 @@ export default function IndexPage() {
     dispatch(resetSecurityCode());
     dispatch(resetCardData());
   }, []);
-  sessionStorage.clear();
+  clearStorage();
 
   return (
     <PageContainer

--- a/src/routes/KOPage.tsx
+++ b/src/routes/KOPage.tsx
@@ -3,13 +3,13 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import ko from "../assets/images/response-umbrella.svg";
 import PageContainer from "../components/PageContent/PageContainer";
+import { Cart } from "../features/payment/models/paymentModel";
 import { useAppDispatch } from "../redux/hooks/hooks";
 import { resetCardData } from "../redux/slices/cardData";
 import { resetSecurityCode } from "../redux/slices/securityCode";
-import { ReturnUrls } from "../features/payment/models/paymentModel";
 import { onBrowserUnload } from "../utils/eventListeners";
 import {
-  clearSensitiveItems,
+  clearStorage,
   getSessionItem,
   SessionItems,
 } from "../utils/storage/sessionStorage";
@@ -18,14 +18,14 @@ export default function KOPage() {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
   const redirectUrl =
-    (getSessionItem(SessionItems.returnUrls) as ReturnUrls | undefined)
-      ?.returnErrorUrl || "/";
+    (getSessionItem(SessionItems.cart) as Cart | undefined)?.returnUrls
+      .returnErrorUrl || "/";
 
   React.useEffect(() => {
     dispatch(resetSecurityCode());
     dispatch(resetCardData());
     window.removeEventListener("beforeunload", onBrowserUnload);
-    clearSensitiveItems();
+    clearStorage();
   }, []);
 
   return (
@@ -62,7 +62,6 @@ export default function KOPage() {
             type="button"
             variant="outlined"
             onClick={() => {
-              sessionStorage.clear();
               window.location.replace(redirectUrl || "/");
             }}
             style={{

--- a/src/routes/PaymentCartPage.tsx
+++ b/src/routes/PaymentCartPage.tsx
@@ -30,16 +30,6 @@ export default function PaymentCartPage() {
   const onResponse = (cart: Cart) => {
     setSessionItem(SessionItems.cart, cart);
     setSessionItem(SessionItems.useremail, cart.emailNotice || "");
-    setSessionItem(
-      SessionItems.returnUrls,
-      cart.returnUrls
-        ? cart.returnUrls
-        : {
-            returnOkUrl: "/",
-            returnCancelUrl: "/",
-            returnErrorUrl: "/",
-          }
-    );
     adaptCartAsPaymentInfo(cart);
     adaptCartAsRptId(cart);
     navigate(`/${CheckoutRoutes.INSERISCI_EMAIL}`, {

--- a/src/routes/PaymentResponsePage.tsx
+++ b/src/routes/PaymentResponsePage.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable sonarjs/cognitive-complexity */
 /* eslint-disable functional/immutable-data */
 /* eslint-disable @typescript-eslint/no-empty-function */
 /* eslint-disable @typescript-eslint/restrict-plus-operands */
@@ -19,7 +20,7 @@ import { mixpanel } from "../utils/config/mixpanelHelperInit";
 import { onBrowserUnload } from "../utils/eventListeners";
 import { moneyFormat } from "../utils/form/formatters";
 import {
-  clearSensitiveItems,
+  clearStorage,
   getSessionItem,
   SessionItems,
 } from "../utils/storage/sessionStorage";
@@ -29,8 +30,8 @@ import {
 } from "../utils/transactions/TransactionResultUtil";
 import { TransactionStatusEnum } from "../../generated/definitions/payment-ecommerce/TransactionStatus";
 import {
+  Cart,
   PspSelected,
-  ReturnUrls,
   Transaction,
 } from "../features/payment/models/paymentModel";
 
@@ -41,12 +42,10 @@ type printData = {
 
 export default function PaymentCheckPage() {
   const [loading, setLoading] = useState(true);
-  const returnUrls = getSessionItem(SessionItems.returnUrls) as
-    | ReturnUrls
-    | undefined;
+  const cart = getSessionItem(SessionItems.cart) as Cart | undefined;
   const [outcomeMessage, setOutcomeMessage] = useState<responseMessage>();
   const [redirectUrl, setRedirectUrl] = useState<string>(
-    returnUrls?.returnOkUrl || "/"
+    cart ? cart.returnUrls.returnOkUrl : "/"
   );
   const transactionData = getSessionItem(SessionItems.transaction) as
     | Transaction
@@ -87,12 +86,18 @@ export default function PaymentCheckPage() {
     const showFinalResult = (outcome: ViewOutcomeEnum) => {
       const message = responseOutcome[outcome];
       const redirectTo =
-        outcome === "0" ? returnUrls?.returnOkUrl : returnUrls?.returnErrorUrl;
+        outcome === "0"
+          ? cart
+            ? cart.returnUrls.returnOkUrl
+            : "/"
+          : cart
+          ? cart.returnUrls.returnErrorUrl
+          : "/";
       setOutcomeMessage(message);
       setRedirectUrl(redirectTo || "");
       setLoading(false);
       window.removeEventListener("beforeunload", onBrowserUnload);
-      clearSensitiveItems();
+      clearStorage();
     };
     void callServices(handleFinalStatusResult);
   }, []);
@@ -136,7 +141,6 @@ export default function PaymentCheckPage() {
               <Button
                 variant="outlined"
                 onClick={() => {
-                  sessionStorage.clear();
                   window.location.replace(redirectUrl);
                 }}
                 sx={{

--- a/src/utils/storage/sessionStorage.ts
+++ b/src/utils/storage/sessionStorage.ts
@@ -3,7 +3,6 @@ import {
   PaymentCheckData,
   PaymentFormFields,
   PaymentInfo,
-  ReturnUrls,
   Wallet,
   PaymentId,
   Transaction,
@@ -25,7 +24,6 @@ export enum SessionItems {
   sessionToken = "sessionToken",
   cart = "cart",
   transaction = "transaction",
-  returnUrls = "returnUrls",
   idTransaction = "idTransaction",
 }
 const isParsable = (item: SessionItems) =>
@@ -53,7 +51,6 @@ export const getSessionItem = (item: SessionItems) => {
           | Wallet
           | Transaction
           | Cart
-          | ReturnUrls
           | PspSelected)
       : serializedState;
   } catch (e) {
@@ -74,7 +71,6 @@ export function setSessionItem(
     | Wallet
     | Transaction
     | Cart
-    | ReturnUrls
     | PspSelected
 ) {
   sessionStorage.setItem(
@@ -85,12 +81,8 @@ export function setSessionItem(
 
 export const isStateEmpty = (item: SessionItems) => !getSessionItem(item);
 
-export const clearSensitiveItems = () => {
-  const originUrl = getSessionItem(SessionItems.returnUrls) as
-    | ReturnUrls
-    | undefined;
+export const clearStorage = () => {
   sessionStorage.clear();
-  setSessionItem(SessionItems.returnUrls, originUrl || "");
 };
 
 export function getReCaptchaKey() {


### PR DESCRIPTION
Use sessionStorage objects only when strictly necessary...

#### List of Changes
- definition of returnUrls' Interface without export, cause we use Cart instead
- drop returnUrls interface from all the files occurred
- refactoring of returnUrls with Cart.returnUrls when needed
- drop of ClearSensitiveItems and creation of ClearStorage (useful to reset sessionStorage dataset)

#### Motivation and Context

We don't need a specific key in sessionStorage to store returnUrls cause when a flow is started from the first page of Checkout every finally CTA (success, ko, cancel, etc) must redirect user to the home. When the flow starts with a Cart we can catch the urls from a subset of info called "returnUrls".

#### How Has This Been Tested?

- Manual
- Linter
- E2e

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


