### PR TITLE
[CHK-1188] add new openapi reference and update model

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "type-check": "tsc",
     "generate": "npm-run-all generate:*",
     "generate:payment-transactions-api": "rimraf generated/definitions/payment-transactions-api && shx mkdir -p generated/definitions/payment-transactions-api && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/pagopa-functions-checkout/v1.1.2/openapi/index.yaml --no-strict --out-dir ./generated/definitions/payment-transactions-api --request-types --response-decoders --client",
-    "generate:payment-ecommerce": "rimraf generated/definitions/payment-ecommerce && shx mkdir -p generated/definitions/payment-ecommerce && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/pagopa-infra/main/src/domains/ecommerce-app/api/ecommerce-checkout/v1/_openapi.json.tpl --no-strict --out-dir ./generated/definitions/payment-ecommerce --request-types --response-decoders --client",
+    "generate:payment-ecommerce": "rimraf generated/definitions/payment-ecommerce && shx mkdir -p generated/definitions/payment-ecommerce && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/pagopa-infra/CHK-1183-changed-payment-methods-get-psp/src/domains/ecommerce-app/api/ecommerce-checkout/v1/_openapi.json.tpl --no-strict --out-dir ./generated/definitions/payment-ecommerce --request-types --response-decoders --client",
     "lint": "eslint . -c .eslintrc.js --ext .ts,.tsx",
     "lint-autofix": "eslint . -c .eslintrc.js --ext .ts,.tsx --fix",
     "prebuild": "npm-run-all generate type-check lint",

--- a/src/features/payment/models/paymentModel.ts
+++ b/src/features/payment/models/paymentModel.ts
@@ -83,14 +83,6 @@ export interface PspSelected {
   fee: number;
 }
 
-export interface PspList {
-  name: string | undefined;
-  label: string | undefined;
-  image: string | undefined;
-  commission: number;
-  idPsp: string | undefined;
-}
-
 export interface PaymentInstruments {
   id: string;
   name: string;

--- a/src/features/payment/models/paymentModel.ts
+++ b/src/features/payment/models/paymentModel.ts
@@ -77,11 +77,6 @@ export interface PaymentMethod {
   paymentMethodId: string;
 }
 
-export interface PspSelected {
-  pspCode: string;
-  businessName: string;
-  fee: number;
-}
 
 export interface PaymentInstruments {
   id: string;

--- a/src/features/payment/models/paymentModel.ts
+++ b/src/features/payment/models/paymentModel.ts
@@ -1,10 +1,6 @@
 import { Theme } from "@emotion/react";
 import { SxProps } from "@mui/material";
-import { ClientIdEnum } from "../../../../generated/definitions/payment-ecommerce/NewTransactionResponse";
-import { TransactionStatusEnum } from "../../../../generated/definitions/payment-ecommerce/TransactionStatus";
-import { PaymentInfo as PaymentData } from "../../../../generated/definitions/payment-ecommerce/PaymentInfo";
 import { TransactionMethods } from "../../../routes/models/paymentMethodRoutes";
-import { AmountEuroCents } from "../../../../generated/definitions/payment-ecommerce/AmountEuroCents";
 
 export interface PaymentFormFields {
   billCode: string;
@@ -109,13 +105,4 @@ export interface Cart {
   paymentNotices: Array<PaymentNotice>;
   returnUrls: ReturnUrls;
   emailNotice?: string;
-}
-
-export interface Transaction {
-  transactionId: string;
-  status: TransactionStatusEnum;
-  payments: ReadonlyArray<PaymentData>;
-  feeTotal?: AmountEuroCents;
-  clientId?: ClientIdEnum;
-  authToken?: string;
 }

--- a/src/features/payment/models/paymentModel.ts
+++ b/src/features/payment/models/paymentModel.ts
@@ -77,7 +77,6 @@ export interface PaymentMethod {
   paymentMethodId: string;
 }
 
-
 export interface PaymentInstruments {
   id: string;
   name: string;

--- a/src/routes/InputCardPage.tsx
+++ b/src/routes/InputCardPage.tsx
@@ -8,10 +8,7 @@ import { pipe } from "fp-ts/function";
 import ErrorModal from "../components/modals/ErrorModal";
 import PageContainer from "../components/PageContent/PageContainer";
 import { InputCardForm } from "../features/payment/components/InputCardForm/InputCardForm";
-import {
-  PaymentMethod,
-  Transaction,
-} from "../features/payment/models/paymentModel";
+import { PaymentMethod } from "../features/payment/models/paymentModel";
 import { useAppDispatch } from "../redux/hooks/hooks";
 import { setCardData } from "../redux/slices/cardData";
 import {
@@ -31,6 +28,7 @@ import {
 } from "../utils/storage/sessionStorage";
 import { BundleOption } from "../../generated/definitions/payment-ecommerce/BundleOption";
 import { Transfer } from "../../generated/definitions/payment-ecommerce/Transfer";
+import { NewTransactionResponse } from "../../generated/definitions/payment-ecommerce/NewTransactionResponse";
 import { CheckoutRoutes } from "./models/routeModel";
 
 export default function InputCardPage() {
@@ -47,8 +45,11 @@ export default function InputCardPage() {
 
   React.useEffect(() => {
     setHideCancelButton(
-      !!(getSessionItem(SessionItems.transaction) as Transaction | undefined)
-        ?.transactionId
+      !!(
+        getSessionItem(SessionItems.transaction) as
+          | NewTransactionResponse
+          | undefined
+      )?.transactionId
     );
   }, []);
 
@@ -111,7 +112,9 @@ export default function InputCardPage() {
       dispatch(setCardData(cardData));
       setLoading(true);
       const transactionId = (
-        getSessionItem(SessionItems.transaction) as Transaction | undefined
+        getSessionItem(SessionItems.transaction) as
+          | NewTransactionResponse
+          | undefined
       )?.transactionId;
       const bin = cardData.pan.substring(0, 8);
       // If I want to change the card data but I have already activated the payment

--- a/src/routes/InputCardPage.tsx
+++ b/src/routes/InputCardPage.tsx
@@ -18,7 +18,7 @@ import {
   activatePayment,
   calculateFees,
   onErrorGetPSP,
-  sortPspByOnUsPolicy,
+  sortPspByThresholdPolicy,
 } from "../utils/api/helper";
 import { InputCardFormFields } from "../features/payment/models/paymentModel";
 import { getConfigOrThrow } from "../utils/config/config";
@@ -87,7 +87,7 @@ export default function InputCardPage() {
           O.map((t) => t.slice()),
           O.getOrElseW(() => [])
         );
-        const firstPsp = sortPspByOnUsPolicy(transferList);
+        const firstPsp = sortPspByThresholdPolicy(transferList);
         setSessionItem(SessionItems.pspSelected, {
           pspCode: firstPsp.at(0)?.idPsp || "",
           fee: firstPsp.at(0)?.taxPayerFee || 0,

--- a/src/routes/InputCardPage.tsx
+++ b/src/routes/InputCardPage.tsx
@@ -68,7 +68,7 @@ export default function InputCardPage() {
     ref.current?.reset();
   };
 
-  const onResponseActivate = async (bin: string) => () =>
+  const onResponseActivate = (bin: string) =>
     getPaymentPSPList({
       paymentMethodId:
         (
@@ -108,7 +108,6 @@ export default function InputCardPage() {
               | PaymentMethod
               | undefined
           )?.paymentMethodId || "",
-        bin: cardData.pan.substring(0, 8),
         onError: onErrorGetPSP,
         onResponse: (resp: Array<PspList>) => {
           const firstPsp = sortPspByOnUsPolicy(resp);
@@ -122,12 +121,13 @@ export default function InputCardPage() {
       const transactionId = (
         getSessionItem(SessionItems.transaction) as Transaction | undefined
       )?.transactionId;
+      const bin = cardData.pan.substring(0, 8);
       // If I want to change the card data but I have already activated the payment
       if (transactionId) {
-        await onResponseActivate(cardData.pan.substring(0, 8));
+        void onResponseActivate(bin);
       } else {
         await activatePayment({
-          bin: cardData.pan.substring(0, 8),
+          bin,
           onResponseActivate,
           onErrorActivate: onError,
         });

--- a/src/routes/InputCardPage.tsx
+++ b/src/routes/InputCardPage.tsx
@@ -91,6 +91,7 @@ export default function InputCardPage() {
               | PaymentMethod
               | undefined
           )?.paymentMethodId || "",
+        bin: cardData.pan.substring(0, 8),
         onError: onErrorGetPSP,
         onResponse: (resp: Array<PspList>) => {
           const firstPsp = sortPspByOnUsPolicy(resp);

--- a/src/routes/InputCardPage.tsx
+++ b/src/routes/InputCardPage.tsx
@@ -15,7 +15,7 @@ import { useAppDispatch } from "../redux/hooks/hooks";
 import { setCardData } from "../redux/slices/cardData";
 import {
   activatePayment,
-  getPaymentPSPList,
+  calculateFees,
   onErrorGetPSP,
   sortPspByOnUsPolicy,
 } from "../utils/api/helper";
@@ -69,7 +69,7 @@ export default function InputCardPage() {
   };
 
   const onResponseActivate = (bin: string) =>
-    getPaymentPSPList({
+    calculateFees({
       paymentMethodId:
         (
           getSessionItem(SessionItems.paymentMethod) as

--- a/src/routes/PaymentCheckPage.tsx
+++ b/src/routes/PaymentCheckPage.tsx
@@ -43,6 +43,7 @@ import {
   calculateFees,
   proceedToPayment,
   sortPspByThresholdPolicy,
+  pspImagePath,
 } from "../utils/api/helper";
 import { onBrowserUnload } from "../utils/eventListeners";
 import { moneyFormat } from "../utils/form/formatters";
@@ -436,7 +437,7 @@ export default function PaymentCheckPage() {
                 key={index}
                 titleVariant="sidenav"
                 bodyVariant="body2"
-                image={psp.abi}
+                image={pspImagePath(psp.abi)}
                 body={psp.bundleName}
                 sx={{
                   ...pspContainerStyle,

--- a/src/routes/PaymentCheckPage.tsx
+++ b/src/routes/PaymentCheckPage.tsx
@@ -33,7 +33,6 @@ import PspFieldContainer from "../components/TextFormField/PspFieldContainer";
 import {
   PaymentInfo,
   PaymentMethod,
-  Transaction,
 } from "../features/payment/models/paymentModel";
 import { useAppSelector } from "../redux/hooks/hooks";
 import { selectCardData } from "../redux/slices/cardData";
@@ -54,6 +53,7 @@ import {
 } from "../utils/storage/sessionStorage";
 import { Transfer } from "../../generated/definitions/payment-ecommerce/Transfer";
 import { BundleOption } from "../../generated/definitions/payment-ecommerce/BundleOption";
+import { NewTransactionResponse } from "../../generated/definitions/payment-ecommerce/NewTransactionResponse";
 import { CheckoutRoutes } from "./models/routeModel";
 
 const defaultStyle = {
@@ -97,7 +97,7 @@ export default function PaymentCheckPage() {
     | Transfer
     | undefined;
   const transaction = getSessionItem(SessionItems.transaction) as
-    | Transaction
+    | NewTransactionResponse
     | undefined;
   const email = getSessionItem(SessionItems.useremail) as string | undefined;
   const amount =

--- a/src/routes/PaymentCheckPage.tsx
+++ b/src/routes/PaymentCheckPage.tsx
@@ -42,7 +42,7 @@ import { selectCardData } from "../redux/slices/cardData";
 import {
   cancelPayment,
   parseDate,
-  getPaymentPSPList,
+  calculateFees,
   proceedToPayment,
 } from "../utils/api/helper";
 import { onBrowserUnload } from "../utils/eventListeners";
@@ -183,7 +183,7 @@ export default function PaymentCheckPage() {
     setDrawerOpen(true);
     setPspEditLoading(true);
     if (paymentMethod) {
-      void getPaymentPSPList({
+      void calculateFees({
         paymentMethodId: paymentMethod?.paymentMethodId,
         bin: cardData?.pan.substring(0, 8),
         onError,

--- a/src/routes/PaymentCheckPage.tsx
+++ b/src/routes/PaymentCheckPage.tsx
@@ -187,7 +187,7 @@ export default function PaymentCheckPage() {
         paymentMethodId: paymentMethod?.paymentMethodId,
         bin: cardData?.pan.substring(0, 8),
         onError,
-        onResponse: onPspEditResponse,
+        onResponsePsp: onPspEditResponse,
       });
     }
   };

--- a/src/routes/PaymentCheckPage.tsx
+++ b/src/routes/PaymentCheckPage.tsx
@@ -188,7 +188,7 @@ export default function PaymentCheckPage() {
     setPspEditLoading(true);
     if (paymentMethod) {
       void calculateFees({
-        paymentMethodId: paymentMethod?.paymentMethodId,
+        paymentTypeCode: paymentMethod?.paymentTypeCode,
         bin: cardData?.pan.substring(0, 8),
         onError,
         onResponsePsp: onPspEditResponse,

--- a/src/routes/PaymentCheckPage.tsx
+++ b/src/routes/PaymentCheckPage.tsx
@@ -33,7 +33,6 @@ import PspFieldContainer from "../components/TextFormField/PspFieldContainer";
 import {
   PaymentInfo,
   PaymentMethod,
-  PspSelected,
   Transaction,
 } from "../features/payment/models/paymentModel";
 import { useAppSelector } from "../redux/hooks/hooks";
@@ -94,7 +93,7 @@ export default function PaymentCheckPage() {
     | PaymentMethod
     | undefined;
   const pspSelected = getSessionItem(SessionItems.pspSelected) as
-    | PspSelected
+    | Transfer
     | undefined;
   const transaction = getSessionItem(SessionItems.transaction) as
     | Transaction
@@ -108,7 +107,7 @@ export default function PaymentCheckPage() {
       transaction?.payments
         .map((p) => p.amount)
         .reduce((sum, current) => sum + current, 0)
-    ) + Number(pspSelected?.fee || 0);
+    ) + Number(pspSelected?.taxPayerFee || 0);
 
   const onBrowserBackEvent = (e: any) => {
     e.preventDefault();
@@ -199,11 +198,7 @@ export default function PaymentCheckPage() {
   const updateWalletPSP = (psp: Transfer) => {
     setDrawerOpen(false);
     setPspUpdateLoading(true);
-    setSessionItem(SessionItems.pspSelected, {
-      pspCode: psp.idPsp || "",
-      fee: psp.taxPayerFee || 0,
-      businessName: psp.bundleName || "",
-    });
+    setSessionItem(SessionItems.pspSelected, psp);
     setPspUpdateLoading(false);
   };
 
@@ -221,7 +216,7 @@ export default function PaymentCheckPage() {
   const isDisabled = () =>
     pspEditLoading || payLoading || cancelLoading || pspUpdateLoading;
 
-  const isDisabledSubmit = () => isDisabled() || pspSelected?.pspCode === "";
+  const isDisabledSubmit = () => isDisabled() || pspSelected?.idPsp === "";
 
   return (
     <PageContainer>
@@ -307,10 +302,10 @@ export default function PaymentCheckPage() {
         loading={pspUpdateLoading}
         titleVariant="sidenav"
         bodyVariant="body2"
-        title={(pspSelected && moneyFormat(pspSelected.fee)) || ""}
+        title={(pspSelected && moneyFormat(pspSelected.taxPayerFee || 0)) || ""}
         body={
           (pspSelected &&
-            `${t("paymentCheckPage.psp")} ${pspSelected.businessName}`) ||
+            `${t("paymentCheckPage.psp")} ${pspSelected.bundleName}`) ||
           ""
         }
         sx={{

--- a/src/routes/PaymentCheckPage.tsx
+++ b/src/routes/PaymentCheckPage.tsx
@@ -185,6 +185,7 @@ export default function PaymentCheckPage() {
     if (paymentMethod) {
       void getPaymentPSPList({
         paymentMethodId: paymentMethod?.paymentMethodId,
+        bin: cardData?.pan.substring(0, 8),
         onError,
         onResponse: onPspEditResponse,
       });

--- a/src/routes/PaymentCheckPage.tsx
+++ b/src/routes/PaymentCheckPage.tsx
@@ -43,6 +43,7 @@ import {
   parseDate,
   calculateFees,
   proceedToPayment,
+  sortPspByThresholdPolicy,
 } from "../utils/api/helper";
 import { onBrowserUnload } from "../utils/eventListeners";
 import { moneyFormat } from "../utils/form/formatters";
@@ -178,11 +179,7 @@ export default function PaymentCheckPage() {
   const onPspEditResponse = (bundleOption: BundleOption) => {
     const transferList: Array<Transfer> =
       bundleOption.bundleOptions?.slice() || [];
-    setPspList(
-      transferList.sort((a, b) =>
-        (a?.taxPayerFee || 0) > (b?.taxPayerFee || 0) ? 1 : -1
-      )
-    );
+    setPspList(sortPspByThresholdPolicy(transferList));
     setPspEditLoading(false);
   };
 

--- a/src/routes/PaymentChoicePage.tsx
+++ b/src/routes/PaymentChoicePage.tsx
@@ -5,6 +5,7 @@ import { Box, Button, Link } from "@mui/material";
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
+import { NewTransactionResponse } from "../../generated/definitions/payment-ecommerce/NewTransactionResponse";
 import { CancelPayment } from "../components/modals/CancelPayment";
 import ErrorModal from "../components/modals/ErrorModal";
 import CheckoutLoader from "../components/PageContent/CheckoutLoader";
@@ -14,7 +15,6 @@ import {
   Cart,
   PaymentInfo,
   PaymentInstruments,
-  Transaction,
 } from "../features/payment/models/paymentModel";
 import { cancelPayment, getPaymentInstruments } from "../utils/api/helper";
 import { getTotalFromCart } from "../utils/cart/cart";
@@ -48,8 +48,11 @@ export default function PaymentChoicePage() {
 
   React.useEffect(() => {
     if (
-      (getSessionItem(SessionItems.transaction) as Transaction | undefined)
-        ?.transactionId
+      (
+        getSessionItem(SessionItems.transaction) as
+          | NewTransactionResponse
+          | undefined
+      )?.transactionId
     ) {
       window.addEventListener("beforeunload", onBrowserUnload);
       window.history.pushState(null, "", window.location.pathname);

--- a/src/routes/PaymentChoicePage.tsx
+++ b/src/routes/PaymentChoicePage.tsx
@@ -5,7 +5,6 @@ import { Box, Button, Link } from "@mui/material";
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
-import { NewTransactionResponse } from "../../generated/definitions/payment-ecommerce/NewTransactionResponse";
 import { CancelPayment } from "../components/modals/CancelPayment";
 import ErrorModal from "../components/modals/ErrorModal";
 import CheckoutLoader from "../components/PageContent/CheckoutLoader";
@@ -18,7 +17,6 @@ import {
 } from "../features/payment/models/paymentModel";
 import { cancelPayment, getPaymentInstruments } from "../utils/api/helper";
 import { getTotalFromCart } from "../utils/cart/cart";
-import { onBrowserUnload } from "../utils/eventListeners";
 import { getSessionItem, SessionItems } from "../utils/storage/sessionStorage";
 import { CheckoutRoutes } from "./models/routeModel";
 
@@ -39,28 +37,6 @@ export default function PaymentChoicePage() {
   const [paymentInstruments, setPaymentInstruments] = React.useState<
     Array<PaymentInstruments>
   >([]);
-
-  const onBrowserBackEvent = (e: any) => {
-    e.preventDefault();
-    window.history.pushState(null, "", window.location.pathname);
-    setCancelModalOpen(true);
-  };
-
-  React.useEffect(() => {
-    if (
-      (
-        getSessionItem(SessionItems.transaction) as
-          | NewTransactionResponse
-          | undefined
-      )?.transactionId
-    ) {
-      window.addEventListener("beforeunload", onBrowserUnload);
-      window.history.pushState(null, "", window.location.pathname);
-      window.addEventListener("popstate", onBrowserBackEvent);
-      return () => window.removeEventListener("popstate", onBrowserBackEvent);
-    }
-    return () => {};
-  }, []);
 
   const getPaymentMethods = React.useCallback(() => {
     setInstrumentsLoading(true);

--- a/src/routes/PaymentResponsePage.tsx
+++ b/src/routes/PaymentResponsePage.tsx
@@ -28,8 +28,9 @@ import {
   ViewOutcomeEnum,
 } from "../utils/transactions/TransactionResultUtil";
 import { TransactionStatusEnum } from "../../generated/definitions/payment-ecommerce/TransactionStatus";
-import { Cart, Transaction } from "../features/payment/models/paymentModel";
+import { Cart } from "../features/payment/models/paymentModel";
 import { Transfer } from "../../generated/definitions/payment-ecommerce/Transfer";
+import { NewTransactionResponse } from "../../generated/definitions/payment-ecommerce/NewTransactionResponse";
 
 type printData = {
   useremail: string;
@@ -44,7 +45,7 @@ export default function PaymentCheckPage() {
     cart ? cart.returnUrls.returnOkUrl : "/"
   );
   const transactionData = getSessionItem(SessionItems.transaction) as
-    | Transaction
+    | NewTransactionResponse
     | undefined;
   const pspSelected = getSessionItem(SessionItems.pspSelected) as
     | Transfer

--- a/src/routes/PaymentResponsePage.tsx
+++ b/src/routes/PaymentResponsePage.tsx
@@ -28,11 +28,8 @@ import {
   ViewOutcomeEnum,
 } from "../utils/transactions/TransactionResultUtil";
 import { TransactionStatusEnum } from "../../generated/definitions/payment-ecommerce/TransactionStatus";
-import {
-  Cart,
-  PspSelected,
-  Transaction,
-} from "../features/payment/models/paymentModel";
+import { Cart, Transaction } from "../features/payment/models/paymentModel";
+import { Transfer } from "../../generated/definitions/payment-ecommerce/Transfer";
 
 type printData = {
   useremail: string;
@@ -50,7 +47,7 @@ export default function PaymentCheckPage() {
     | Transaction
     | undefined;
   const pspSelected = getSessionItem(SessionItems.pspSelected) as
-    | PspSelected
+    | Transfer
     | undefined;
   const email = getSessionItem(SessionItems.useremail) as string | undefined;
   const totalAmount =
@@ -58,7 +55,7 @@ export default function PaymentCheckPage() {
       transactionData?.payments
         .map((p) => p.amount)
         .reduce((sum, current) => sum + current, 0)
-    ) + Number(pspSelected?.fee);
+    ) + Number(pspSelected?.taxPayerFee);
 
   const usefulPrintData: printData = {
     useremail: email || "",

--- a/src/utils/api/helper.ts
+++ b/src/utils/api/helper.ts
@@ -340,13 +340,15 @@ export const getPaymentPSPList = async ({
   const pspList = await pipe(
     TE.tryCatch(
       () =>
-        apiPaymentEcommerceClient.getPaymentMethodsPSPs({
-          id: paymentMethodId,
+        apiPaymentEcommerceClient.calculateFees({
+          maxOccurrences: undefined,
           body: {
             bin,
+            touchpoint: "CHECKOUT",
+            paymentMethodId,
             paymentAmount: amount ? amount : 0,
-            primaryCreditorInstitution: "", //TODO get value from session when available
-            transferList: [], //TODO get value from session when available
+            primaryCreditorInstitution: "", // TODO get value from session when available
+            transferList: [], // TODO get value from session when available
           },
         }),
       (_e) => {
@@ -392,8 +394,8 @@ export const getPaymentPSPList = async ({
   const psp = pspList?.map((e) => ({
     name: e?.bundleName,
     label: e?.bundleDescription,
-    image: "https://assets.cdn.io.italia.it/logos/abi/"
-      .concat(e?.abi || "")
+    image: getConfigOrThrow()
+      .CHECKOUT_PAGOPA_ASSETS_CDN.concat(e?.abi || "")
       .concat(".png"),
     commission: e?.taxPayerFee ?? 0,
     idPsp: e?.idPsp,

--- a/src/utils/api/helper.ts
+++ b/src/utils/api/helper.ts
@@ -164,11 +164,13 @@ export const getEcommercePaymentInfoTask = (
   );
 
 export const activatePayment = async ({
-  onResponse,
-  onError,
+  bin,
+  onResponseActivate,
+  onErrorActivate,
 }: {
-  onResponse: () => void;
-  onError: (e: string) => void;
+  bin: string;
+  onResponseActivate: (bin: string) => void;
+  onErrorActivate: (e: string) => void;
 }) => {
   const noticeInfo = getSessionItem(SessionItems.noticeInfo) as
     | PaymentFormFields
@@ -183,7 +185,7 @@ export const activatePayment = async ({
   pipe(
     PaymentRequestsGetResponse.decode(paymentInfo),
     E.fold(
-      () => onError(ErrorsType.INVALID_DECODE),
+      () => onErrorActivate(ErrorsType.INVALID_DECODE),
       (response) =>
         pipe(
           activePaymentTask(
@@ -194,11 +196,11 @@ export const activatePayment = async ({
           ),
           TE.fold(
             (e: string) => async () => {
-              onError(e);
+              onErrorActivate(e);
             },
             (res) => async () => {
               setSessionItem(SessionItems.transaction, res);
-              onResponse();
+              onResponseActivate(bin);
             }
           )
         )()
@@ -304,12 +306,12 @@ export const getPaymentPSPList = async ({
   paymentMethodId,
   bin,
   onError,
-  onResponse,
+  onResponsePsp,
 }: {
   paymentMethodId: string;
   bin: string;
   onError: (e: string) => void;
-  onResponse: (r: Array<PspList>) => void;
+  onResponsePsp: (r: Array<PspList>) => void;
 }) => {
   const amount: number | undefined = pipe(
     O.fromNullable(getSessionItem(SessionItems.cart) as Cart | undefined),
@@ -397,7 +399,7 @@ export const getPaymentPSPList = async ({
     idPsp: e?.idPsp,
   }));
 
-  onResponse(psp || []);
+  onResponsePsp(psp || []);
 };
 
 export const proceedToPayment = async (

--- a/src/utils/api/helper.ts
+++ b/src/utils/api/helper.ts
@@ -345,8 +345,8 @@ export const getPaymentPSPList = async ({
           body: {
             bin,
             paymentAmount: amount ? amount : 0,
-            primaryCreditorInstitution: "",
-            transferList: [],
+            primaryCreditorInstitution: "", //TODO get value from session when available
+            transferList: [], //TODO get value from session when available
           },
         }),
       (_e) => {

--- a/src/utils/api/helper.ts
+++ b/src/utils/api/helper.ts
@@ -390,9 +390,11 @@ export const getPaymentPSPList = async ({
   const psp = pspList?.map((e) => ({
     name: e?.bundleName,
     label: e?.bundleDescription,
-    image: e?.abi, // image: e?.logoPSP, TODO capire come gestire i loghi
+    image: "https://assets.cdn.io.italia.it/logos/abi/"
+      .concat(e?.abi || "")
+      .concat(".png"),
     commission: e?.taxPayerFee ?? 0,
-    idPsp: e?.idPsp, // TODO gestito come stringa
+    idPsp: e?.idPsp,
   }));
 
   onResponse(psp || []);

--- a/src/utils/api/helper.ts
+++ b/src/utils/api/helper.ts
@@ -18,7 +18,6 @@ import {
   PaymentInfo,
   PaymentInstruments,
   PaymentMethod,
-  PspSelected,
   Transaction,
 } from "../../features/payment/models/paymentModel";
 import {
@@ -476,14 +475,14 @@ export const proceedToPayment = async (
       .map((p) => p.amount)
       .reduce((sum, current) => Number(sum) + Number(current), 0),
     fee:
-      (getSessionItem(SessionItems.pspSelected) as PspSelected | undefined)
-        ?.fee || 0,
+      (getSessionItem(SessionItems.pspSelected) as Transfer | undefined)
+        ?.taxPayerFee || 0,
     paymentInstrumentId:
       (getSessionItem(SessionItems.paymentMethod) as PaymentMethod | undefined)
         ?.paymentMethodId || "",
     pspId:
-      (getSessionItem(SessionItems.pspSelected) as PspSelected | undefined)
-        ?.pspCode || "",
+      (getSessionItem(SessionItems.pspSelected) as Transfer | undefined)
+        ?.idPsp || "",
     details:
       (getSessionItem(SessionItems.paymentMethod) as PaymentMethod | undefined)
         ?.paymentTypeCode === "CP"

--- a/src/utils/api/helper.ts
+++ b/src/utils/api/helper.ts
@@ -759,10 +759,10 @@ export const onErrorGetPSP = (e: string): void => {
   throw new Error("Error getting psp list. " + e);
 };
 
-export const sortPspByOnUsPolicy = (
+export const sortPspByThresholdPolicy = (
   transferList: Array<Transfer>
 ): Array<Transfer> =>
-  // TODO Implement OnUs/NotOnUs sorting?
+  // TODO Missing OnUs/NotOnUs sorting and threshold evaluation?
   transferList
     .slice()
     .sort((a, b) => ((a?.taxPayerFee || 0) > (b?.taxPayerFee || 0) ? 1 : -1));

--- a/src/utils/api/helper.ts
+++ b/src/utils/api/helper.ts
@@ -302,7 +302,7 @@ const activePaymentTask = (
     )
   );
 
-export const getPaymentPSPList = async ({
+export const calculateFees = async ({
   paymentMethodId,
   bin,
   onError,
@@ -332,6 +332,16 @@ export const getPaymentPSPList = async ({
     O.getOrElseW(() => undefined)
   );
 
+  const primaryCreditorInstitution = pipe(
+    O.fromNullable(getSessionItem(SessionItems.transaction) as Transaction),
+    O.map((transaction) => transaction.transactionId) //TODO replace with primaryCreditorInstitution property when available
+  )
+
+  const transferList = pipe(
+    O.fromNullable(getSessionItem(SessionItems.transaction) as Transaction),
+    O.map(() => []) //TODO replace with primaryCreditorInstitution property when available
+  )
+
   // const lang = "it";
 
   mixpanel.track(PAYMENT_PSPLIST_INIT.value, {
@@ -347,8 +357,14 @@ export const getPaymentPSPList = async ({
             touchpoint: "CHECKOUT",
             paymentMethodId,
             paymentAmount: amount ? amount : 0,
-            primaryCreditorInstitution: "", // TODO get value from session when available
-            transferList: [], // TODO get value from session when available
+            primaryCreditorInstitution: pipe(
+              primaryCreditorInstitution,
+              O.getOrElse(() => "")
+            ),
+            transferList: pipe(
+              transferList,
+              O.getOrElse(() => [])
+            ),
           },
         }),
       (_e) => {

--- a/src/utils/api/helper.ts
+++ b/src/utils/api/helper.ts
@@ -873,3 +873,16 @@ const getBrandByBrandCardValidator = (
       return BrandEnum.UNKNOWN;
   }
 };
+
+export const pspImagePath = (abi: string | undefined): string =>
+  pipe(
+    abi,
+    O.fromNullable,
+    O.map((abi) =>
+      getConfigOrThrow()
+        .CHECKOUT_PAGOPA_ASSETS_CDN.concat("/")
+        .concat(abi)
+        .concat(".png")
+    ),
+    O.getOrElse(() => "")
+  );

--- a/src/utils/api/helper.ts
+++ b/src/utils/api/helper.ts
@@ -7,8 +7,10 @@ import { toError } from "fp-ts/lib/Either";
 import * as O from "fp-ts/Option";
 import * as TE from "fp-ts/TaskEither";
 import * as T from "fp-ts/Task";
-import { RequestAuthorizationRequest } from "../../../generated/definitions/payment-ecommerce/RequestAuthorizationRequest";
-import { LanguageEnum } from "../../../generated/definitions/payment-ecommerce/Psp";
+import {
+  LanguageEnum,
+  RequestAuthorizationRequest,
+} from "../../../generated/definitions/payment-ecommerce/RequestAuthorizationRequest";
 import { RptId } from "../../../generated/definitions/payment-ecommerce/RptId";
 import { ValidationFaultPaymentProblemJson } from "../../../generated/definitions/payment-ecommerce/ValidationFaultPaymentProblemJson";
 import {
@@ -303,12 +305,12 @@ const activePaymentTask = (
   );
 
 export const calculateFees = async ({
-  paymentMethodId,
+  paymentTypeCode,
   bin,
   onError,
   onResponsePsp,
 }: {
-  paymentMethodId: string;
+  paymentTypeCode: string;
   bin: string;
   onError: (e: string) => void;
   onResponsePsp: (r: BundleOption) => void;
@@ -348,8 +350,6 @@ export const calculateFees = async ({
   const primaryCreditorInstitution =
     transferList.at(0)?.creditorInstitution || ""; // TODO replace with primaryCreditorInstitution from transaction response when available (activate V2)
 
-  // const lang = "it";
-
   mixpanel.track(PAYMENT_PSPLIST_INIT.value, {
     EVENT_ID: PAYMENT_PSPLIST_INIT.value,
   });
@@ -361,7 +361,7 @@ export const calculateFees = async ({
           body: {
             bin,
             touchpoint: "CHECKOUT",
-            paymentMethodId,
+            paymentMethod: paymentTypeCode,
             paymentAmount: amount ? amount : 0,
             primaryCreditorInstitution,
             transferList,

--- a/src/utils/api/response.ts
+++ b/src/utils/api/response.ts
@@ -22,11 +22,11 @@ import {
   createClient,
   Client as EcommerceClient,
 } from "../../../generated/definitions/payment-ecommerce/client";
-import { TransactionInfo } from "../../../generated/definitions/payment-ecommerce/TransactionInfo";
 import { TransactionStatusEnum } from "../../../generated/definitions/payment-ecommerce/TransactionStatus";
 import { EcommerceFinalStatusCodeEnumType } from "../transactions/TransactionResultUtil";
 import { getSessionItem, SessionItems } from "../storage/sessionStorage";
-import { Transaction } from "../../features/payment/models/paymentModel";
+import { NewTransactionResponse } from "../../../generated/definitions/payment-ecommerce/NewTransactionResponse";
+import { TransactionInfo } from "../../../generated/definitions/payment-ecommerce/TransactionInfo";
 const config = getConfigOrThrow();
 /**
  * Polling configuration params
@@ -67,7 +67,7 @@ export const callServices = async (
   handleFinalStatusResult: (idStatus?: TransactionStatusEnum) => void
 ) => {
   const transaction = getSessionItem(SessionItems.transaction) as
-    | Transaction
+    | NewTransactionResponse
     | undefined;
 
   const bearerAuth = pipe(

--- a/src/utils/storage/sessionStorage.ts
+++ b/src/utils/storage/sessionStorage.ts
@@ -1,3 +1,4 @@
+import { Transfer } from "../../../generated/definitions/payment-ecommerce/Transfer";
 import {
   Cart,
   PaymentFormFields,
@@ -6,7 +7,6 @@ import {
   Transaction,
   PaymentEmailFormFields,
   PaymentMethod,
-  PspSelected,
 } from "../../features/payment/models/paymentModel";
 import { getConfigOrThrow } from "../config/config";
 
@@ -39,7 +39,7 @@ export const getSessionItem = (item: SessionItems) => {
           | PaymentId
           | Transaction
           | Cart
-          | PspSelected)
+          | Transfer)
       : serializedState;
   } catch (e) {
     return undefined;
@@ -57,7 +57,7 @@ export function setSessionItem(
     | PaymentId
     | Transaction
     | Cart
-    | PspSelected
+    | Transfer
 ) {
   sessionStorage.setItem(
     name,

--- a/src/utils/storage/sessionStorage.ts
+++ b/src/utils/storage/sessionStorage.ts
@@ -1,10 +1,10 @@
+import { NewTransactionResponse } from "../../../generated/definitions/payment-ecommerce/NewTransactionResponse";
 import { Transfer } from "../../../generated/definitions/payment-ecommerce/Transfer";
 import {
   Cart,
   PaymentFormFields,
   PaymentInfo,
   PaymentId,
-  Transaction,
   PaymentEmailFormFields,
   PaymentMethod,
 } from "../../features/payment/models/paymentModel";
@@ -37,7 +37,7 @@ export const getSessionItem = (item: SessionItems) => {
           | PaymentFormFields
           | PaymentEmailFormFields
           | PaymentId
-          | Transaction
+          | NewTransactionResponse
           | Cart
           | Transfer)
       : serializedState;
@@ -55,7 +55,7 @@ export function setSessionItem(
     | PaymentEmailFormFields
     | PaymentMethod
     | PaymentId
-    | Transaction
+    | NewTransactionResponse
     | Cart
     | Transfer
 ) {


### PR DESCRIPTION
This pr use new calculateFee api from ecommerce to get psp list

#### List of Changes

Change api invocation for psp list
Remove PspSelected, PspList and Transaction data structure from PaymentModel. Use in place of the autogenerated data structure from openapi.
Update activate/getPsp(calucateFee) flow.

#### Motivation and Context

Tune checkout to the new api exposed from payment-methods that now asks for psp list from gec. Since new data structures are involved the old ones has been deleted

#### How Has This Been Tested?

Test were performed locally. Integration test fails in pipeline since the mock branch has to be merged (https://github.com/pagopa/pagopa-checkout-be-mock/pull/33). Integration tests performed locally are successfully 

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
