### PR TITLE
[CHK-1298] Disabling redux devTools in PROD

### DIFF
--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -2,6 +2,8 @@ import { combineReducers, configureStore } from "@reduxjs/toolkit";
 import cardDataReducer from "./slices/cardData";
 import thresholdReducer from "./slices/threshold";
 
+const { CHECKOUT_ENV } = process.env;
+
 const reducer = combineReducers({
   cardData: cardDataReducer,
   threshold: thresholdReducer,
@@ -9,6 +11,7 @@ const reducer = combineReducers({
 
 const store = configureStore({
   reducer,
+  devTools: CHECKOUT_ENV !== "PROD",
 });
 
 export default store;


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
The redux devTools will be not available in production.

<!--- Describe your changes in detail -->

#### Motivation and Context
It's much more safer to does not expose via redux devTools the internal FE state. 
Actions/events that could alter the FE behaviour could be dispatched when redux devTools are enabled.

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

Tested locally updating the CHECKOUT_ENV environment variable with 'DEV' | 'UAT' | 'PROD' values.
Then I verified in the browser if the redux devTools were enabled or not.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
