### PR TITLE
fill trasfert list with first value coming from activationV2

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "type-check": "tsc",
     "generate": "npm-run-all generate:*",
     "generate:payment-transactions-api": "rimraf generated/definitions/payment-transactions-api && shx mkdir -p generated/definitions/payment-transactions-api && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/pagopa-functions-checkout/v1.1.2/openapi/index.yaml --no-strict --out-dir ./generated/definitions/payment-transactions-api --request-types --response-decoders --client",
-    "generate:payment-ecommerce": "rimraf generated/definitions/payment-ecommerce && shx mkdir -p generated/definitions/payment-ecommerce && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/pagopa-infra/main/src/domains/ecommerce-app/api/ecommerce-checkout/v1/_openapi.json.tpl --no-strict --out-dir ./generated/definitions/payment-ecommerce --request-types --response-decoders --client",
+    "generate:payment-ecommerce": "rimraf generated/definitions/payment-ecommerce && shx mkdir -p generated/definitions/payment-ecommerce && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/pagopa-infra/CHK-1131-update-payment-info/src/domains/ecommerce-app/api/ecommerce-checkout/v1/_openapi.json.tpl --no-strict --out-dir ./generated/definitions/payment-ecommerce --request-types --response-decoders --client",
     "lint": "eslint . -c .eslintrc.js --ext .ts,.tsx",
     "lint-autofix": "eslint . -c .eslintrc.js --ext .ts,.tsx --fix",
     "prebuild": "npm-run-all generate type-check lint",

--- a/src/utils/api/helper.ts
+++ b/src/utils/api/helper.ts
@@ -333,11 +333,12 @@ export const calculateFees = async ({
   const transferList: Array<TransferListItem> = pipe(
     getSessionItem(SessionItems.transaction) as NewTransactionResponse,
     O.fromNullable,
-    O.map((transaction) => transaction.payments),
-    O.map((payments) =>
-      payments.map((p) => ({
-        creditorInstitution: p.rptId.substring(0, 11),
-        digitalStamp: false,
+    O.map((transaction) => transaction.payments[0].transferList), // TODO By now we can handle only single rptId notice, since GEC is not compliant with multiple rptIds notice (cart)
+    O.map((transferList) =>
+      transferList.map((transfer) => ({
+        creditorInstitution: transfer.paFiscalCode,
+        digitalStamp: transfer.digitalStamp,
+        transferCategory: transfer.transferCategory,
       }))
     ),
     O.getOrElse(() => [] as Array<TransferListItem>)


### PR DESCRIPTION
Update transfer list for calculate fee 

#### List of Changes

Update infra refers
Update transfer list building on calculateFee

#### Motivation and Context

After introducing activateV2 in transactionService, the transfer list to send to gec comes from transaction dedicated fields.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
