### PR TITLE
[CHK-1690] Qualtrics survey on thank you page

### DIFF
--- a/src/components/commons/SurveyLink.tsx
+++ b/src/components/commons/SurveyLink.tsx
@@ -3,9 +3,20 @@ import { Typography, Alert, AlertTitle, Link, Box } from "@mui/material";
 import { useTranslation } from "react-i18next";
 import { ThemeProvider } from "@mui/material";
 import { theme } from "@pagopa/mui-italia";
+import { VOC_USER_EXIT } from "../../utils/config/mixpanelDefs";
+import { mixpanel } from "../../utils/config/mixpanelHelperInit";
 
 const SurveyLink = () => {
   const { t } = useTranslation();
+
+  const onClick = () => {
+    mixpanel.track(VOC_USER_EXIT.value, {
+      EVENT_ID: VOC_USER_EXIT.value,
+      event_category: "UX",
+      event_type: "exit",
+      screen_name: "payment response page",
+    });
+  };
 
   return (
     <ThemeProvider theme={theme}>
@@ -20,6 +31,7 @@ const SurveyLink = () => {
             {t("paymentResponsePage.survey.body")}
           </Typography>
           <Link
+            onClick={onClick}
             variant="body1"
             target="_blank"
             rel="nofollow"

--- a/src/components/commons/SurveyLink.tsx
+++ b/src/components/commons/SurveyLink.tsx
@@ -1,0 +1,40 @@
+import { default as React } from "react";
+import { Typography, Alert, AlertTitle, Link, useTheme } from "@mui/material";
+import { useTranslation } from "react-i18next";
+import { mixpanel } from "../../utils/config/mixpanelHelperInit";
+
+const SurveyLink = () => {
+  const theme = useTheme();
+  const { t } = useTranslation();
+
+  const onClick = () => {
+    mixpanel.track("hereNewMixpanelActionId", {
+      EVENT_ID: "hereNewMixpanelActionId",
+    });
+  };
+
+  return (
+    <Alert
+      severity="info"
+      variant="standard"
+      sx={{
+        borderLeftColor: theme.palette.info.main + " !important",
+        borderLeft: "4px solid",
+      }}
+    >
+      <AlertTitle>{t("paymentResponsePage.survey.title")}</AlertTitle>
+      <Typography variant="body1">
+        {t("paymentResponsePage.survey.body")}
+      </Typography>
+      <Link
+        target="_blank"
+        href={t("paymentResponsePage.survey.link.href")}
+        onClick={onClick}
+      >
+        {t("paymentResponsePage.survey.link.text")}
+      </Link>
+    </Alert>
+  );
+};
+
+export default SurveyLink;

--- a/src/components/commons/SurveyLink.tsx
+++ b/src/components/commons/SurveyLink.tsx
@@ -1,10 +1,11 @@
 import { default as React } from "react";
-import { Typography, Alert, AlertTitle, Link, useTheme } from "@mui/material";
+import { Typography, Alert, AlertTitle, Link } from "@mui/material";
 import { useTranslation } from "react-i18next";
+import { ThemeProvider } from "@mui/material";
+import { theme } from "@pagopa/mui-italia";
 import { mixpanel } from "../../utils/config/mixpanelHelperInit";
 
 const SurveyLink = () => {
-  const theme = useTheme();
   const { t } = useTranslation();
 
   const onClick = () => {
@@ -14,26 +15,36 @@ const SurveyLink = () => {
   };
 
   return (
-    <Alert
-      severity="info"
-      variant="standard"
-      sx={{
-        borderLeftColor: theme.palette.info.main + " !important",
-        borderLeft: "4px solid",
-      }}
-    >
-      <AlertTitle>{t("paymentResponsePage.survey.title")}</AlertTitle>
-      <Typography variant="body1">
-        {t("paymentResponsePage.survey.body")}
-      </Typography>
-      <Link
-        target="_blank"
-        href={t("paymentResponsePage.survey.link.href")}
-        onClick={onClick}
+    <ThemeProvider theme={theme}>
+      <Alert
+        icon={false}
+        severity="info"
+        variant="standard"
+        sx={{
+          borderLeftColor: theme.palette.info.main + " !important",
+          borderLeft: "4px solid",
+          padding: "16px",
+        }}
       >
-        {t("paymentResponsePage.survey.link.text")}
-      </Link>
-    </Alert>
+        <AlertTitle>
+          <Typography variant="body1" sx={{ fontWeight: 600 }} mb={1}>
+            {t("paymentResponsePage.survey.title")}
+          </Typography>
+        </AlertTitle>
+        <Typography variant="body1" mb={2}>
+          {t("paymentResponsePage.survey.body")}
+        </Typography>
+        <Link
+          variant="body1"
+          target="_blank"
+          href={t("paymentResponsePage.survey.link.href")}
+          onClick={onClick}
+          sx={{ textDecoration: "none", fontWeight: 700 }}
+        >
+          {t("paymentResponsePage.survey.link.text")}
+        </Link>
+      </Alert>
+    </ThemeProvider>
   );
 };
 

--- a/src/components/commons/SurveyLink.tsx
+++ b/src/components/commons/SurveyLink.tsx
@@ -1,5 +1,5 @@
 import { default as React } from "react";
-import { Typography, Alert, AlertTitle, Link } from "@mui/material";
+import { Typography, Alert, AlertTitle, Link, Box } from "@mui/material";
 import { useTranslation } from "react-i18next";
 import { ThemeProvider } from "@mui/material";
 import { theme } from "@pagopa/mui-italia";
@@ -9,33 +9,26 @@ const SurveyLink = () => {
 
   return (
     <ThemeProvider theme={theme}>
-      <Alert
-        icon={false}
-        severity="info"
-        variant="standard"
-        sx={{
-          borderLeftColor: theme.palette.info.main + " !important",
-          borderLeft: "4px solid",
-          padding: "16px",
-        }}
-      >
-        <AlertTitle>
-          <Typography variant="body1" sx={{ fontWeight: 600 }} mb={1}>
-            {t("paymentResponsePage.survey.title")}
+      <Alert icon={false} severity="info" variant="standard">
+        <Box p={2}>
+          <AlertTitle>
+            <Typography variant="body1" sx={{ fontWeight: 600 }} mb={1}>
+              {t("paymentResponsePage.survey.title")}
+            </Typography>
+          </AlertTitle>
+          <Typography variant="body1" mb={2}>
+            {t("paymentResponsePage.survey.body")}
           </Typography>
-        </AlertTitle>
-        <Typography variant="body1" mb={2}>
-          {t("paymentResponsePage.survey.body")}
-        </Typography>
-        <Link
-          variant="body1"
-          target="_blank"
-          rel="nofollow"
-          href={t("paymentResponsePage.survey.link.href")}
-          sx={{ textDecoration: "none", fontWeight: 700 }}
-        >
-          {t("paymentResponsePage.survey.link.text")}
-        </Link>
+          <Link
+            variant="body1"
+            target="_blank"
+            rel="nofollow"
+            href={t("paymentResponsePage.survey.link.href")}
+            sx={{ textDecoration: "none", fontWeight: 700 }}
+          >
+            {t("paymentResponsePage.survey.link.text")}
+          </Link>
+        </Box>
       </Alert>
     </ThemeProvider>
   );

--- a/src/components/commons/SurveyLink.tsx
+++ b/src/components/commons/SurveyLink.tsx
@@ -3,16 +3,9 @@ import { Typography, Alert, AlertTitle, Link } from "@mui/material";
 import { useTranslation } from "react-i18next";
 import { ThemeProvider } from "@mui/material";
 import { theme } from "@pagopa/mui-italia";
-import { mixpanel } from "../../utils/config/mixpanelHelperInit";
 
 const SurveyLink = () => {
   const { t } = useTranslation();
-
-  const onClick = () => {
-    mixpanel.track("hereNewMixpanelActionId", {
-      EVENT_ID: "hereNewMixpanelActionId",
-    });
-  };
 
   return (
     <ThemeProvider theme={theme}>
@@ -37,8 +30,8 @@ const SurveyLink = () => {
         <Link
           variant="body1"
           target="_blank"
+          rel="nofollow"
           href={t("paymentResponsePage.survey.link.href")}
-          onClick={onClick}
           sx={{ textDecoration: "none", fontWeight: 700 }}
         >
           {t("paymentResponsePage.survey.link.text")}

--- a/src/routes/PaymentResponsePage.tsx
+++ b/src/routes/PaymentResponsePage.tsx
@@ -92,6 +92,7 @@ export default function PaymentResponsePage() {
         idStatus,
         outcome,
       });
+      setOutcome(outcome);
       showFinalResult(outcome);
     };
 
@@ -105,7 +106,6 @@ export default function PaymentResponsePage() {
           : cart
           ? cart.returnUrls.returnErrorUrl
           : "/";
-      setOutcome(outcome);
       setOutcomeMessage(message);
       setRedirectUrl(redirectTo || "");
       setLoading(false);
@@ -176,7 +176,7 @@ export default function PaymentResponsePage() {
               </Button>
             </Box>
             {outcome === ViewOutcomeEnum.SUCCESS && (
-              <Box>
+              <Box sx={{ width: "100%" }}>
                 <SurveyLink />
               </Box>
             )}

--- a/src/routes/PaymentResponsePage.tsx
+++ b/src/routes/PaymentResponsePage.tsx
@@ -176,7 +176,7 @@ export default function PaymentResponsePage() {
               </Button>
             </Box>
             {outcome === ViewOutcomeEnum.SUCCESS && (
-              <Box sx={{ width: "100%" }} px={{ xs: 8, sm: 4 }}>
+              <Box sx={{ width: "100%" }} px={{ xs: 8, sm: 0 }}>
                 <SurveyLink />
               </Box>
             )}

--- a/src/routes/PaymentResponsePage.tsx
+++ b/src/routes/PaymentResponsePage.tsx
@@ -5,6 +5,7 @@
 import { Box, Button, Typography } from "@mui/material";
 import { default as React, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import SurveyLink from "../components/commons/SurveyLink";
 import CheckoutLoader from "../components/PageContent/CheckoutLoader";
 import PageContainer from "../components/PageContent/PageContainer";
 import {
@@ -44,6 +45,7 @@ type printData = {
 export default function PaymentResponsePage() {
   const [loading, setLoading] = useState(true);
   const cart = getSessionItem(SessionItems.cart) as Cart | undefined;
+  const [outcome, setOutcome] = useState<ViewOutcomeEnum>();
   const [outcomeMessage, setOutcomeMessage] = useState<responseMessage>();
   const [redirectUrl, setRedirectUrl] = useState<string>(
     cart ? cart.returnUrls.returnOkUrl : "/"
@@ -103,6 +105,7 @@ export default function PaymentResponsePage() {
           : cart
           ? cart.returnUrls.returnErrorUrl
           : "/";
+      setOutcome(outcome);
       setOutcomeMessage(message);
       setRedirectUrl(redirectTo || "");
       setLoading(false);
@@ -172,6 +175,11 @@ export default function PaymentResponsePage() {
                 {t("errorButton.close")}
               </Button>
             </Box>
+            {outcome === ViewOutcomeEnum.SUCCESS && (
+              <Box>
+                <SurveyLink />
+              </Box>
+            )}
           </Box>
         )}
       </Box>

--- a/src/routes/PaymentResponsePage.tsx
+++ b/src/routes/PaymentResponsePage.tsx
@@ -176,7 +176,7 @@ export default function PaymentResponsePage() {
               </Button>
             </Box>
             {outcome === ViewOutcomeEnum.SUCCESS && (
-              <Box sx={{ width: "100%" }}>
+              <Box sx={{ width: "100%" }} px={{ xs: 8, sm: 4 }}>
                 <SurveyLink />
               </Box>
             )}

--- a/src/translations/it/translations.ts
+++ b/src/translations/it/translations.ts
@@ -317,7 +317,7 @@ export const TRANSLATIONS_IT = {
       body: "Raccontaci la tua esperienza con il pagamento e aiutaci a migliorare.",
       link: {
         text: "Vai al sondaggio",
-        href: "https://pagopa.qualtrics.com/jfe/form/SV_064FV80j4PXaUsu",
+        href: "https://pagopa.gov.it/diccilatua/ces-pagamento",
       },
     },
   },

--- a/src/translations/it/translations.ts
+++ b/src/translations/it/translations.ts
@@ -312,6 +312,14 @@ export const TRANSLATIONS_IT = {
       title: "L'operazione è stata presa in carico",
       body: "Riceverai l’esito del pagamento all'indirizzo {{useremail}}",
     },
+    survey: {
+      title: "Puoi dirci come è andata?",
+      body: "Raccontaci la tua esperienza con il pagamento e aiutaci a migliorare",
+      link: {
+        text: "Vai al sondaggio",
+        href: "https://pagopa.qualtrics.com/jfe/form/SV_064FV80j4PXaUsu",
+      },
+    },
   },
   cancelledPage: {
     body: "L'operazione è stata annullata",

--- a/src/translations/it/translations.ts
+++ b/src/translations/it/translations.ts
@@ -317,7 +317,7 @@ export const TRANSLATIONS_IT = {
       body: "Raccontaci la tua esperienza con il pagamento e aiutaci a migliorare.",
       link: {
         text: "Vai al sondaggio",
-        href: "https://pagopa.gov.it/diccilatua/ces-pagamento",
+        href: "https://pagopa.gov.it/diccilatua/ces-pagamento/",
       },
     },
   },

--- a/src/translations/it/translations.ts
+++ b/src/translations/it/translations.ts
@@ -313,8 +313,8 @@ export const TRANSLATIONS_IT = {
       body: "Riceverai l’esito del pagamento all'indirizzo {{useremail}}",
     },
     survey: {
-      title: "Puoi dirci come è andata?",
-      body: "Raccontaci la tua esperienza con il pagamento e aiutaci a migliorare",
+      title: "Puoi dirci com'è andata?",
+      body: "Raccontaci la tua esperienza con il pagamento e aiutaci a migliorare.",
       link: {
         text: "Vai al sondaggio",
         href: "https://pagopa.qualtrics.com/jfe/form/SV_064FV80j4PXaUsu",

--- a/src/utils/config/mixpanelDefs.ts
+++ b/src/utils/config/mixpanelDefs.ts
@@ -463,3 +463,6 @@ export const TRANSACTION_AUTH_RESP_ERROR = t.literal(
 export type TRANSACTION_AUTH_RESP_ERROR = t.TypeOf<
   typeof TRANSACTION_AUTH_RESP_ERROR
 >;
+
+export const VOC_USER_EXIT = t.literal("VOC_USER_EXIT");
+export type VOC_USER_EXIT = t.TypeOf<typeof VOC_USER_EXIT>;


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

Added an info alert component which includes a link to a Qualtrics survey on the thank you page (alert visible only when the payment is ok)

#### Motivation and Context
The purpose is to measure the ease of the payment process experience
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Tested locally using the be-mock as backend and simulating an ok and ko payment
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):
<img width="402" alt="image" src="https://github.com/pagopa/pagopa-checkout-fe/assets/34749257/44be958d-2676-45be-8e3f-e8b49bec0cb3">

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
