### PR TITLE
fix(checkout) CHK-1761 enforce rptid regex

### DIFF
--- a/src/features/payment/components/PaymentNoticeForm/PaymentNoticeForm.tsx
+++ b/src/features/payment/components/PaymentNoticeForm/PaymentNoticeForm.tsx
@@ -27,14 +27,14 @@ export function PaymentNoticeForm(props: {
     const errors: PaymentFormErrors = {
       ...(values.billCode
         ? {
-            ...(/\b\d{18}\b/.test(values.billCode)
+            ...(/\b^\d{18}$\b/.test(values.billCode)
               ? {}
               : { billCode: "paymentNoticePage.formErrors.minCode" }),
           }
         : { billCode: "paymentNoticePage.formErrors.required" }),
       ...(values.cf
         ? {
-            ...(/\b\d{11}\b/.test(values.cf)
+            ...(/\b^\d{11}$\b/.test(values.cf)
               ? {}
               : { cf: "paymentNoticePage.formErrors.minCf" }),
           }


### PR DESCRIPTION
Same as #241 but based on develop branch

Enforce the input regex to valid insert payment notice number page form

#### List of Changes

Upgrade regex input to check if the input string for the rpt id is a string of exactly 18 digits for payment notice number and 11 digits for pa fiscal code

#### Motivation and Context

This PR addresses a log evidence about the fact that eCommerce receives some dirty inputs from checkout frontend.
Old regex `\d{18}` and `\d{11}` for notice number and pa fiscal code validated respectively input as `302000100000009424-` and `77777777777-` (note the ending dash)

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
