### PR TITLE
[Chk-1822] feat(sessions): invoke payment sessions method to retrieve card data

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "type-check": "tsc",
     "generate": "npm-run-all generate:*",
     "generate:payment-transactions-api": "rimraf generated/definitions/payment-transactions-api && shx mkdir -p generated/definitions/payment-transactions-api && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/pagopa-functions-checkout/v1.1.2/openapi/index.yaml --no-strict --out-dir ./generated/definitions/payment-transactions-api --request-types --response-decoders --client",
-    "generate:payment-ecommerce": "rimraf generated/definitions/payment-ecommerce && shx mkdir -p generated/definitions/payment-ecommerce && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/pagopa-infra/main/src/domains/ecommerce-app/api/ecommerce-checkout/v1/_openapi.json.tpl --no-strict --out-dir ./generated/definitions/payment-ecommerce --request-types --response-decoders --client",
+    "generate:payment-ecommerce": "rimraf generated/definitions/payment-ecommerce && shx mkdir -p generated/definitions/payment-ecommerce && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/pagopa-infra/4b4ed539a6889d5a13f87274ced5151e91e6c654/src/domains/ecommerce-app/api/ecommerce-checkout/v1/_openapi.json.tpl --no-strict --out-dir ./generated/definitions/payment-ecommerce --request-types --response-decoders --client",
     "lint": "eslint . -c .eslintrc.js --ext .ts,.tsx",
     "lint-autofix": "eslint . -c .eslintrc.js --ext .ts,.tsx --fix",
     "prebuild": "npm-run-all generate type-check lint",

--- a/src/features/payment/components/IframeCardForm/IframeCardForm.tsx
+++ b/src/features/payment/components/IframeCardForm/IframeCardForm.tsx
@@ -9,7 +9,6 @@ import {
 } from "../../../../utils/storage/sessionStorage";
 import { FormButtons } from "../../../../components/FormButtons/FormButtons";
 import { PaymentMethod } from "../../../../features/payment/models/paymentModel";
-import { Field, RenderField } from "./IframeCardField";
 import ReCAPTCHA from "react-google-recaptcha";
 import { useNavigate } from "react-router-dom";
 import * as O from "fp-ts/Option";
@@ -19,9 +18,9 @@ import {
   activatePayment,
   calculateFees,
   npgSessionsFields,
-  retrieveCardData
+  retrieveCardData,
 } from "../../../../utils/api/helper";
-import { CreateSessionResponse, SessionPaymentMethodResponse } from "../../../../../generated/definitions/payment-ecommerce/SessionPaymentMethodResponse";
+import { SessionPaymentMethodResponse } from "../../../../../generated/definitions/payment-ecommerce/SessionPaymentMethodResponse";
 import { CheckoutRoutes } from "../../../../routes/models/routeModel";
 import { Bundle } from "../../../../../generated/definitions/payment-ecommerce/Bundle";
 import { CalculateFeeResponse } from "../../../../../generated/definitions/payment-ecommerce/CalculateFeeResponse";
@@ -29,6 +28,7 @@ import { ErrorsType } from "../../../../utils/errors/checkErrorsModel";
 import { useAppDispatch } from "../../../../redux/hooks/hooks";
 import { setThreshold } from "../../../../redux/slices/threshold";
 import { RenderField } from "./IframeCardField";
+import { CreateSessionResponse } from "../../../../../generated/definitions/payment-ecommerce/CreateSessionResponse";
 
 interface Props {
   loading?: boolean;
@@ -64,7 +64,7 @@ Object.values(IdFields).forEach((k) => {
 
 // eslint-disable-next-line sonarjs/cognitive-complexity
 export default function IframeCardForm(props: Props) {
-  const { loading = true, onCancel, hideCancel } = props;
+  const { onCancel, hideCancel } = props;
   const navigate = useNavigate();
   const [loading, setLoading] = React.useState(false);
   const [error, setError] = React.useState("");
@@ -240,9 +240,7 @@ export default function IframeCardForm(props: Props) {
           onBuildFlowStateChange(
             _evtData: any,
             state:
-              | "
-            
-            PAYMENT"
+              | "READY_FOR_PAYMENT"
               | "REDIRECTED_TO_EXTERNAL_DOMAIN"
               | "PAYMENT_COMPLETE"
           ) {

--- a/src/features/payment/components/IframeCardForm/IframeCardForm.tsx
+++ b/src/features/payment/components/IframeCardForm/IframeCardForm.tsx
@@ -75,7 +75,7 @@ export default function IframeCardForm(props: Props) {
   const { onCancel, hideCancel } = props;
   const navigate = useNavigate();
   const [loading, setLoading] = React.useState(false);
-  const [errorModalOpen, setErrorModalOpen] = React.useState(false);
+  const [setErrorModalOpen] = React.useState(false);
   const [error, setError] = React.useState("");
   const [form, setForm] = React.useState<BuildResp>();
   const [spinner, setSpinner] = React.useState(loading);
@@ -94,7 +94,9 @@ export default function IframeCardForm(props: Props) {
   const onError = (m: string) => {
     setLoading(false);
     setError(m);
-    setErrorModalOpen(true);
+    // the on error function as defined till now should open the error modal.
+    // By the way we are developing the happy path and we can face this issue when we manage the error path
+    // setErrorModalOpen(true);
     ref.current?.reset();
   };
 

--- a/src/features/payment/components/IframeCardForm/IframeCardForm.tsx
+++ b/src/features/payment/components/IframeCardForm/IframeCardForm.tsx
@@ -177,7 +177,7 @@ export default function IframeCardForm(props: Props) {
             | PaymentMethod
             | undefined
         )?.paymentMethodId || "",
-        "sessionId"
+        getSessionItem(SessionItems.sessiondId) as string
       );
     } else {
       await activatePayment({
@@ -202,6 +202,7 @@ export default function IframeCardForm(props: Props) {
             }
           );
           const body = (await response.json()) as BuildResp;
+          setSessionItem(SessionItems.sessiondId, body.sessionId);
           setForm(body);
         } catch (e) {
           onError(ErrorsType.GENERIC_ERROR);

--- a/src/features/payment/components/IframeCardForm/IframeCardForm.tsx
+++ b/src/features/payment/components/IframeCardForm/IframeCardForm.tsx
@@ -177,7 +177,7 @@ export default function IframeCardForm(props: Props) {
             | PaymentMethod
             | undefined
         )?.paymentMethodId || "",
-        getSessionItem(SessionItems.sessiondId) as string
+        getSessionItem(SessionItems.sessionId) as string
       );
     } else {
       await activatePayment({
@@ -202,7 +202,7 @@ export default function IframeCardForm(props: Props) {
             }
           );
           const body = (await response.json()) as BuildResp;
-          setSessionItem(SessionItems.sessiondId, body.sessionId);
+          setSessionItem(SessionItems.sessionId, body.sessionId);
           setForm(body);
         } catch (e) {
           onError(ErrorsType.GENERIC_ERROR);

--- a/src/features/payment/components/IframeCardForm/IframeCardForm.tsx
+++ b/src/features/payment/components/IframeCardForm/IframeCardForm.tsx
@@ -75,7 +75,6 @@ export default function IframeCardForm(props: Props) {
   const { onCancel, hideCancel } = props;
   const navigate = useNavigate();
   const [loading, setLoading] = React.useState(false);
-  const [setErrorModalOpen] = React.useState(false);
   const [error, setError] = React.useState("");
   const [form, setForm] = React.useState<BuildResp>();
   const [spinner, setSpinner] = React.useState(loading);

--- a/src/features/payment/components/IframeCardForm/IframeCardForm.tsx
+++ b/src/features/payment/components/IframeCardForm/IframeCardForm.tsx
@@ -95,8 +95,6 @@ export default function IframeCardForm(props: Props) {
     setLoading(false);
     setError(m);
     setErrorModalOpen(true);
-    // eslint-disable-next-line no-console
-    console.log(errorModalOpen);
     ref.current?.reset();
   };
 
@@ -168,8 +166,6 @@ export default function IframeCardForm(props: Props) {
         | NewTransactionResponse
         | undefined
     )?.transactionId;
-    // eslint-disable-next-line no-console
-    console.log(transactionId);
     if (transactionId) {
       void retrievePaymentSession(
         (

--- a/src/features/payment/components/IframeCardForm/IframeCardForm.tsx
+++ b/src/features/payment/components/IframeCardForm/IframeCardForm.tsx
@@ -1,13 +1,32 @@
+/* eslint-disable import/order */
 import React from "react";
 import { Box } from "@mui/material";
 import { useTranslation } from "react-i18next";
 import {
   getSessionItem,
   SessionItems,
+  setSessionItem,
 } from "../../../../utils/storage/sessionStorage";
 import { FormButtons } from "../../../../components/FormButtons/FormButtons";
 import { PaymentMethod } from "../../../../features/payment/models/paymentModel";
 import { Field, RenderField } from "./IframeCardField";
+import ReCAPTCHA from "react-google-recaptcha";
+import { useNavigate } from "react-router-dom";
+import * as O from "fp-ts/Option";
+import { pipe } from "fp-ts/function";
+import { NewTransactionResponse } from "../../../../../generated/definitions/payment-ecommerce/NewTransactionResponse";
+import {
+  activatePayment,
+  calculateFees,
+  retrieveCardData,
+} from "../../../../utils/api/helper";
+import { SessionPaymentMethodResponse } from "../../../../../generated/definitions/payment-ecommerce/SessionPaymentMethodResponse";
+import { CheckoutRoutes } from "../../../../routes/models/routeModel";
+import { Bundle } from "../../../../../generated/definitions/payment-ecommerce/Bundle";
+import { CalculateFeeResponse } from "../../../../../generated/definitions/payment-ecommerce/CalculateFeeResponse";
+import { ErrorsType } from "../../../../utils/errors/checkErrorsModel";
+import { useAppDispatch } from "../../../../redux/hooks/hooks";
+import { setThreshold } from "../../../../redux/slices/threshold";
 
 interface Props {
   loading?: boolean;
@@ -53,19 +72,121 @@ Object.values(IdFields).forEach((k) => {
 
 // eslint-disable-next-line sonarjs/cognitive-complexity
 export default function IframeCardForm(props: Props) {
-  const { loading = true, onCancel, hideCancel } = props;
-  const [error, setError] = React.useState(false);
+  const { onCancel, hideCancel } = props;
+  const navigate = useNavigate();
+  const [loading, setLoading] = React.useState(false);
+  const [errorModalOpen, setErrorModalOpen] = React.useState(false);
+  const [error, setError] = React.useState("");
   const [form, setForm] = React.useState<BuildResp>();
   const [spinner, setSpinner] = React.useState(loading);
   const [enabledForm, setEnabledForm] = React.useState(false);
+  const ref = React.useRef<ReCAPTCHA>(null);
   // this dummy state is only used to permorm a component udpate, not the best solution but works
   const [, setDummyState] = React.useState(0);
+  const dispatch = useAppDispatch();
 
   const [buildInstance, setBuildInstance] = React.useState();
 
   const calculateFormValidStatus = (
     fieldformStatus: Map<string, FieldFormStatus>
   ) => Array.from(fieldformStatus.values()).every((el) => el.isValid);
+
+  const onError = (m: string) => {
+    setLoading(false);
+    setError(m);
+    setErrorModalOpen(true);
+    // eslint-disable-next-line no-console
+    console.log(errorModalOpen);
+    ref.current?.reset();
+  };
+
+  const getFees = (bin: string) =>
+    calculateFees({
+      paymentId:
+        (
+          getSessionItem(SessionItems.paymentMethod) as
+            | PaymentMethod
+            | undefined
+        )?.paymentMethodId || "",
+      bin,
+      onError,
+      onResponsePsp: (resp) => {
+        pipe(
+          resp,
+          CalculateFeeResponse.decode,
+          O.fromEither,
+          O.chain((resp) => O.fromNullable(resp.belowThreshold)),
+          O.fold(
+            () => onError(ErrorsType.GENERIC_ERROR),
+            (value) => {
+              dispatch(setThreshold({ belowThreshold: value }));
+              const firstPsp = pipe(
+                resp?.bundles,
+                O.fromNullable,
+                O.chain((sortedArray) => O.fromNullable(sortedArray[0])),
+                O.map((a) => a as Bundle),
+                O.getOrElseW(() => ({}))
+              );
+
+              setSessionItem(SessionItems.pspSelected, firstPsp);
+              setLoading(false);
+              navigate(`/${CheckoutRoutes.RIEPILOGO_PAGAMENTO}`);
+            }
+          )
+        );
+      },
+    });
+
+  const retrievePaymentSession = (paymentMethodId: string, sessionId: string) =>
+    retrieveCardData({
+      paymentId: paymentMethodId,
+      sessionId,
+      onError,
+      onResponseSessionPaymentMethod: (resp) => {
+        pipe(
+          resp,
+          SessionPaymentMethodResponse.decode,
+          O.fromEither,
+          O.chain((resp) => O.fromNullable(resp.bin)),
+          O.fold(
+            () => onError(ErrorsType.GENERIC_ERROR),
+            () => getFees(resp.bin)
+          )
+        );
+      },
+    });
+
+  const transaction = async () => {
+    const recaptchaResponse = await ref.current?.executeAsync();
+    const token = pipe(
+      recaptchaResponse,
+      O.fromNullable,
+      O.getOrElse(() => "")
+    );
+    const transactionId = (
+      getSessionItem(SessionItems.transaction) as
+        | NewTransactionResponse
+        | undefined
+    )?.transactionId;
+    // eslint-disable-next-line no-console
+    console.log(transactionId);
+    if (transactionId) {
+      void retrievePaymentSession(
+        (
+          getSessionItem(SessionItems.paymentMethod) as
+            | PaymentMethod
+            | undefined
+        )?.paymentMethodId || "",
+        "sessionId"
+      );
+    } else {
+      await activatePayment({
+        token,
+        onResponseActivate: retrievePaymentSession,
+        onErrorActivate: onError,
+      });
+    }
+  };
 
   React.useEffect(() => {
     if (!form) {
@@ -83,7 +204,7 @@ export default function IframeCardForm(props: Props) {
           const body = (await response.json()) as BuildResp;
           setForm(body);
         } catch (e) {
-          setError(true);
+          onError(ErrorsType.GENERIC_ERROR);
         } finally {
           setSpinner(false);
         }
@@ -162,14 +283,12 @@ export default function IframeCardForm(props: Props) {
           //   the evtData.data.url external domain for strong customer authentication (i.e ACS URL).
           // PAYMENT_COMPLETE: the payment experience is finished. It is required to invoke
           //   the get https://{nexiDomain}/api/phoenix-0.0/psp/api/v1/build/state?sessionId={thesessionId}  },
-          // console.log("onBuildFlowStateChange", evtData, state);
+          // eslint-disable-next-line no-console
+          console.log("onBuildFlowStateChange", _evtData, state);
           if (state === "READY_FOR_PAYMENT") {
-            console.log("DENTRO")
-            void (async () => {
-              // TO-DO
-            })();
+            void transaction();
           } else {
-            setError(true);
+            onError(ErrorsType.GENERIC_ERROR);
           }
         },
         cssLink: `${protocol}//${hostname}${
@@ -194,7 +313,7 @@ export default function IframeCardForm(props: Props) {
       buildInstance.confirmData(() => setSpinner(false));
     } catch (e) {
       setSpinner(false);
-      setError(true);
+      onError(ErrorsType.GENERIC_ERROR);
     }
   };
   const { t } = useTranslation();

--- a/src/routes/IframeCardPage.tsx
+++ b/src/routes/IframeCardPage.tsx
@@ -37,67 +37,6 @@ export default function IFrameCardPage() {
     );
   }, []);
 
-  /*
-  const onError = (m: string) => {
-    setLoading(false);
-    setError(m);
-    setErrorModalOpen(true);
-    ref.current?.reset();
-  };
-  
-
-  const retrievePaymentSession = (paymentMethodId: string, sessionId: string) =>
-    retrieveCardData({
-      paymentId: paymentMethodId,
-      sessionId,
-      onError,
-      onResponseSessionPaymentMethod: (resp) => {
-        pipe(
-          resp,
-          SessionPaymentMethodResponse.decode,
-          E.map((resp) => getFees(resp.bin)),
-          E.mapLeft(() => onError(ErrorsType.GENERIC_ERROR))
-        );
-      },
-    });
-
-  const getFees = (bin: string) =>
-    calculateFees({
-      paymentId:
-        (
-          getSessionItem(SessionItems.paymentMethod) as
-            | PaymentMethod
-            | undefined
-        )?.paymentMethodId || "",
-      bin,
-      onError,
-      onResponsePsp: (resp) => {
-        pipe(
-          resp,
-          CalculateFeeResponse.decode,
-          O.fromEither,
-          O.chain((resp) => O.fromNullable(resp.belowThreshold)),
-          O.fold(
-            () => onError(ErrorsType.GENERIC_ERROR),
-            (value) => {
-              dispatch(setThreshold({ belowThreshold: value }));
-              const firstPsp = pipe(
-                resp?.bundles,
-                O.fromNullable,
-                O.chain((sortedArray) => O.fromNullable(sortedArray[0])),
-                O.map((a) => a as Bundle),
-                O.getOrElseW(() => ({}))
-              );
-
-              setSessionItem(SessionItems.pspSelected, firstPsp);
-              setLoading(false);
-              navigate(`/${CheckoutRoutes.RIEPILOGO_PAGAMENTO}`);
-            }
-          )
-        );
-      },
-    });
-*/
   const onCancel = () => navigate(-1);
   return (
     <PageContainer title="inputCardPage.title">

--- a/src/routes/IframeCardPage.tsx
+++ b/src/routes/IframeCardPage.tsx
@@ -143,7 +143,7 @@ export default function InputCardPage() {
             | PaymentMethod
             | undefined
         )?.paymentMethodId || "",
-        getSessionItem(SessionItems.sessiondId) as string
+        getSessionItem(SessionItems.sessionId) as string
       );
     } else {
       await activatePayment({

--- a/src/routes/IframeCardPage.tsx
+++ b/src/routes/IframeCardPage.tsx
@@ -2,44 +2,27 @@ import { Box } from "@mui/material";
 import React from "react";
 import ReCAPTCHA from "react-google-recaptcha";
 import { useNavigate } from "react-router-dom";
-import * as O from "fp-ts/Option";
 import * as E from "fp-ts/Either";
 import { pipe } from "fp-ts/function";
-import { setThreshold } from "../redux/slices/threshold";
-import ErrorModal from "../components/modals/ErrorModal";
 import PageContainer from "../components/PageContent/PageContainer";
-// import { InputCardForm } from "../features/payment/components/InputCardForm/InputCardForm";
 import IframeCardForm from "../features/payment/components/IframeCardForm/IframeCardForm";
-import { PaymentMethod } from "../features/payment/models/paymentModel";
-import { useAppDispatch } from "../redux/hooks/hooks";
-import {
-  activatePayment,
-  calculateFees,
-  retrieveCardData,
-} from "../utils/api/helper";
-import { ErrorsType } from "../utils/errors/checkErrorsModel";
 import {
   getReCaptchaKey,
   getSessionItem,
   SessionItems,
-  setSessionItem,
 } from "../utils/storage/sessionStorage";
 import { NewTransactionResponse } from "../../generated/definitions/payment-ecommerce/NewTransactionResponse";
-import { CalculateFeeResponse } from "../../generated/definitions/payment-ecommerce/CalculateFeeResponse";
-import { Bundle } from "../../generated/definitions/payment-ecommerce/Bundle";
-import { SessionPaymentMethodResponse } from "../../generated/definitions/payment-ecommerce/SessionPaymentMethodResponse";
-import { CheckoutRoutes } from "./models/routeModel";
 
 export default function IFrameCardPage() {
   const navigate = useNavigate();
-  const [loading, setLoading] = React.useState(false);
-  const [errorModalOpen, setErrorModalOpen] = React.useState(false);
-  const [error, setError] = React.useState("");
+  const [loading] = React.useState(false);
+  // const [errorModalOpen, setErrorModalOpen] = React.useState(false);
+  // const [error, setError] = React.useState("");
   // Is It allowed to store the bin temporary?
   // const [bin, setBin] = React.useState("");
   const [hideCancelButton, setHideCancelButton] = React.useState(false);
   const ref = React.useRef<ReCAPTCHA>(null);
-  const dispatch = useAppDispatch();
+  // const dispatch = useAppDispatch();
 
   React.useEffect(() => {
     setHideCancelButton(
@@ -54,12 +37,14 @@ export default function IFrameCardPage() {
     );
   }, []);
 
+  /*
   const onError = (m: string) => {
     setLoading(false);
     setError(m);
     setErrorModalOpen(true);
     ref.current?.reset();
   };
+  
 
   const retrievePaymentSession = (paymentMethodId: string, sessionId: string) =>
     retrieveCardData({
@@ -112,69 +97,17 @@ export default function IFrameCardPage() {
         );
       },
     });
-
-  const onSubmit = React.useCallback(async () => {
-    setLoading(true);
-    const recaptchaResponse = await ref.current?.executeAsync();
-    const token = pipe(
-      recaptchaResponse,
-      O.fromNullable,
-      O.getOrElse(() => "")
-    );
-    const transactionId = (
-      getSessionItem(SessionItems.transaction) as
-        | NewTransactionResponse
-        | undefined
-    )?.transactionId;
-    // const bin = cardData.pan.substring(0, 6);
-    // If I want to change the card data but I have already activated the payment
-    if (transactionId) {
-      void retrievePaymentSession(
-        (
-          getSessionItem(SessionItems.paymentMethod) as
-            | PaymentMethod
-            | undefined
-        )?.paymentMethodId || "",
-        getSessionItem(SessionItems.sessionId) as string
-      );
-    } else {
-      await activatePayment({
-        token,
-        onResponseActivate: retrievePaymentSession,
-        onErrorActivate: onError,
-      });
-    }
-  }, [ref, error]);
-
-  const onRetry = React.useCallback(() => {
-    setErrorModalOpen(false);
-    void onSubmit();
-  }, [error]);
-
+*/
   const onCancel = () => navigate(-1);
   return (
     <PageContainer title="inputCardPage.title">
       <Box sx={{ mt: 6 }}>
         <IframeCardForm
           onCancel={onCancel}
-          onSubmit={onSubmit}
           hideCancel={hideCancelButton}
           loading={loading}
         />
       </Box>
-      {!!error && (
-        <ErrorModal
-          error={error}
-          open={errorModalOpen}
-          onClose={() => {
-            setErrorModalOpen(false);
-          }}
-          onRetry={onRetry}
-          titleId="inputCardPageErrorTitleId"
-          errorId="inputCardPageErrorId"
-          bodyId="inputCardPageErrorBodyId"
-        />
-      )}
       <Box display="none">
         <ReCAPTCHA
           ref={ref}

--- a/src/routes/IframeCardPage.tsx
+++ b/src/routes/IframeCardPage.tsx
@@ -143,7 +143,7 @@ export default function InputCardPage() {
             | PaymentMethod
             | undefined
         )?.paymentMethodId || "",
-        "sessionId"
+        getSessionItem(SessionItems.sessiondId) as string
       );
     } else {
       await activatePayment({

--- a/src/routes/IframeCardPage.tsx
+++ b/src/routes/IframeCardPage.tsx
@@ -30,7 +30,7 @@ import { Bundle } from "../../generated/definitions/payment-ecommerce/Bundle";
 import { SessionPaymentMethodResponse } from "../../generated/definitions/payment-ecommerce/SessionPaymentMethodResponse";
 import { CheckoutRoutes } from "./models/routeModel";
 
-export default function InputCardPage() {
+export default function IFrameCardPage() {
   const navigate = useNavigate();
   const [loading, setLoading] = React.useState(false);
   const [errorModalOpen, setErrorModalOpen] = React.useState(false);
@@ -114,14 +114,6 @@ export default function InputCardPage() {
     });
 
   const onSubmit = React.useCallback(async () => {
-    /* const cardData = {
-          brand: cardValidator.number(wallet.number).card?.type || "",
-          expDate: wallet.expirationDate,
-          cardHolderName: wallet.name,
-          cvv: wallet.cvv,
-          pan: wallet.number,
-        };
-        dispatch(setCardData(cardData)); */
     setLoading(true);
     const recaptchaResponse = await ref.current?.executeAsync();
     const token = pipe(

--- a/src/routes/InputCardPage.tsx
+++ b/src/routes/InputCardPage.tsx
@@ -120,7 +120,6 @@ export default function InputCardPage() {
         void onResponseActivate(bin);
       } else {
         await activatePayment({
-          bin,
           token,
           onResponseActivate,
           onErrorActivate: onError,

--- a/src/routes/PaymentCheckPage.tsx
+++ b/src/routes/PaymentCheckPage.tsx
@@ -262,13 +262,7 @@ export default function PaymentCheckPage() {
         titleVariant="sidenav"
         bodyVariant="body2"
         title={`· · · · ${sessionPaymentMethodResponse.lastFourDigits}`}
-        body={`${sessionPaymentMethodResponse.expiringDate.slice(
-          0,
-          2
-        )}/${sessionPaymentMethodResponse.expiringDate.slice(
-          4,
-          6
-        )} · ${cardHolderName}`}
+        body={`${sessionPaymentMethodResponse.expiringDate} · ${cardHolderName}`}
         icon={<WalletIcon brand={sessionPaymentMethodResponse.brand || ""} />}
         sx={{
           border: "1px solid",

--- a/src/utils/api/helper.ts
+++ b/src/utils/api/helper.ts
@@ -191,7 +191,7 @@ export const activatePayment = async ({
   const paymentMethod: PaymentMethod = getSessionItem(
     SessionItems.paymentMethod
   ) as PaymentMethod;
-  const sessionId: string = getSessionItem(SessionItems.sessiondId) as string;
+  const sessionId: string = getSessionItem(SessionItems.sessionId) as string;
   pipe(
     PaymentRequestsGetResponse.decode(paymentInfo),
     E.fold(

--- a/src/utils/api/helper.ts
+++ b/src/utils/api/helper.ts
@@ -191,7 +191,7 @@ export const activatePayment = async ({
   const paymentMethod: PaymentMethod = getSessionItem(
     SessionItems.paymentMethod
   ) as PaymentMethod;
-  const sessionId: string = "sessionId";
+  const sessionId: string = getSessionItem(SessionItems.sessiondId) as string;
   pipe(
     PaymentRequestsGetResponse.decode(paymentInfo),
     E.fold(

--- a/src/utils/storage/sessionStorage.ts
+++ b/src/utils/storage/sessionStorage.ts
@@ -21,6 +21,7 @@ export enum SessionItems {
   cart = "cart",
   transaction = "transaction",
   sessionPaymentMethod = "sessionPayment",
+  sessiondId = "sessionId",
 }
 const isParsable = (item: SessionItems) =>
   !(item === SessionItems.sessionToken || item === SessionItems.useremail);

--- a/src/utils/storage/sessionStorage.ts
+++ b/src/utils/storage/sessionStorage.ts
@@ -21,10 +21,14 @@ export enum SessionItems {
   cart = "cart",
   transaction = "transaction",
   sessionPaymentMethod = "sessionPayment",
-  sessiondId = "sessionId",
+  sessionId = "sessionId",
 }
 const isParsable = (item: SessionItems) =>
-  !(item === SessionItems.sessionToken || item === SessionItems.useremail);
+  !(
+    item === SessionItems.sessionToken ||
+    item === SessionItems.useremail ||
+    item === SessionItems.sessionId
+  );
 
 export const getSessionItem = (item: SessionItems) => {
   try {

--- a/src/utils/storage/sessionStorage.ts
+++ b/src/utils/storage/sessionStorage.ts
@@ -1,5 +1,6 @@
 import { Bundle } from "../../../generated/definitions/payment-ecommerce/Bundle";
 import { NewTransactionResponse } from "../../../generated/definitions/payment-ecommerce/NewTransactionResponse";
+import { SessionPaymentMethodResponse } from "../../../generated/definitions/payment-ecommerce/SessionPaymentMethodResponse";
 import {
   Cart,
   PaymentFormFields,
@@ -19,6 +20,7 @@ export enum SessionItems {
   sessionToken = "sessionToken",
   cart = "cart",
   transaction = "transaction",
+  sessionPaymentMethod = "sessionPayment",
 }
 const isParsable = (item: SessionItems) =>
   !(item === SessionItems.sessionToken || item === SessionItems.useremail);
@@ -39,7 +41,8 @@ export const getSessionItem = (item: SessionItems) => {
           | PaymentId
           | NewTransactionResponse
           | Cart
-          | Bundle)
+          | Bundle
+          | SessionPaymentMethodResponse)
       : serializedState;
   } catch (e) {
     return undefined;
@@ -58,6 +61,7 @@ export function setSessionItem(
     | NewTransactionResponse
     | Cart
     | Bundle
+    | SessionPaymentMethodResponse
 ) {
   sessionStorage.setItem(
     name,


### PR DESCRIPTION
Add the frontend logic to invoke payment method sessions when npg is ready for payment

#### List of Changes

- add invoke function when npg is in ready_to_payment state
- add invoke to npg session api via payment-methods bewtween post transaction and calculate fees
- adapt frontend to new data structure

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
