### PR TITLE
[CHK-1818] mui ux IframeCardField and refactor

### DIFF
--- a/src/features/payment/components/IframeCardForm/IframeCardField.tsx
+++ b/src/features/payment/components/IframeCardForm/IframeCardField.tsx
@@ -1,8 +1,9 @@
-import React from "react";
 import { Box, FormControl, FormHelperText, InputLabel } from "@mui/material";
+import { SxProps } from "@mui/system";
+import React from "react";
 import { useTranslation } from "react-i18next";
 import { Field } from "../../../../../generated/definitions/payment-ecommerce/Field";
-import { IdFields } from "./IframeCardForm";
+import { IdFields } from "./types";
 
 interface Props {
   label: string;
@@ -11,12 +12,20 @@ interface Props {
   style?: React.CSSProperties;
   errorCode?: string | null;
   errorMessage?: string | null;
+  isValid?: boolean;
 }
 
 const getSrcFromFieldsByID = (
   fields: ReadonlyArray<Field>,
   id: keyof typeof IdFields
 ) => fields.find((field) => field.id === id)?.src;
+
+interface Styles {
+  formControl: SxProps;
+  label: SxProps;
+  box: SxProps;
+  iframe: React.CSSProperties;
+}
 
 export function RenderField(props: Props) {
   if (!props.fields) {
@@ -25,55 +34,99 @@ export function RenderField(props: Props) {
   if (!props.id) {
     return <Box></Box>;
   }
-  const src = getSrcFromFieldsByID(props.fields, props.id);
+
+  const { fields, id, errorCode, errorMessage, label } = props;
+  const { t } = useTranslation();
+  const styles = useStyles(props);
+
+  // Find src based on ID
+  const src = getSrcFromFieldsByID(fields, id);
   if (!src) {
     return <Box></Box>;
   }
 
-  const { t } = useTranslation();
-
   return (
-    <>
-      <FormControl fullWidth={true} margin="dense" sx={{ marginY: 3 }}>
-        <InputLabel
-          margin="dense"
-          shrink={true}
-          sx={{
-            background: "#fff",
-            paddingX: 1,
-          }}
-        >
-          {props.label}
-        </InputLabel>
-        <Box
-          sx={{
-            borderRadius: 1,
-            padding: 2,
-            borderColor: "grey.400",
-            borderStyle: "solid",
-            borderWidth: "1px",
-            position: "relative",
-          }}
-        >
-          <iframe
-            src={src}
-            style={{
-              display: "block",
-              border: "none",
-              height: 30,
-              width: "100%",
-              ...props.style,
-            }}
-          />
-        </Box>
-        {(props.errorMessage || props.errorCode) && (
-          <FormHelperText required={true} error={true}>
-            {t(`errorMessageNPG.${props.errorCode}`, {
-              defaultValue: props.errorMessage,
-            })}
-          </FormHelperText>
-        )}
-      </FormControl>
-    </>
+    <FormControl sx={styles.formControl}>
+      {/* Input label */}
+      <InputLabel sx={styles.label} margin="dense" shrink>
+        {label}
+      </InputLabel>
+      {/* Box with embedded content */}
+      <Box sx={styles.box}>
+        {src && <iframe src={src} style={styles.iframe} />}
+      </Box>
+      {/* Error message or code */}
+      {(errorMessage || errorCode) && (
+        <FormHelperText required error>
+          {t(`errorMessageNPG.${errorCode}`, {
+            defaultValue: errorMessage,
+          })}
+        </FormHelperText>
+      )}
+    </FormControl>
   );
 }
+
+const COLORS = {
+  LABEL: "#5c6f82",
+  BOX: "#c4c4c4",
+  VALID: "#0073e6",
+  INVALID: "#d85757",
+  HOVER: "#17324D",
+};
+
+// Function to calculate border styles based on validity
+const borderStyles = (isValid: boolean | undefined) => {
+  // If validity is defined, determine colors for valid or invalid state
+  if (isValid !== undefined) {
+    const validityColor = isValid ? COLORS.VALID : COLORS.INVALID;
+    return {
+      labelColor: validityColor,
+      boxColor: validityColor,
+      hoverShadowWidth: "2px",
+      hoverShadowColor: validityColor,
+    };
+  }
+
+  // Default styles for undefined validity (neutral state)
+  return {
+    labelColor: COLORS.LABEL,
+    boxColor: COLORS.BOX,
+    hoverShadowWidth: "1px",
+    hoverShadowColor: COLORS.HOVER,
+  };
+};
+
+const useStyles = ({ isValid, style }: Props): Styles => {
+  const borderStyle = borderStyles(isValid);
+
+  return {
+    formControl: {
+      width: "100%",
+      margin: "dense",
+      marginY: 3,
+    },
+    label: {
+      background: "#fff",
+      paddingX: 1,
+      color: borderStyle.labelColor,
+    },
+    box: {
+      borderRadius: "4px",
+      padding: 2,
+      position: "relative",
+      boxShadow: `0 0 0 1px ${borderStyle.boxColor}`,
+      transition: "box-shadow 0.1s ease-in",
+      "&:hover": {
+        boxShadow: `0 0 0 ${borderStyle.hoverShadowWidth} ${borderStyle.hoverShadowColor}`,
+      },
+    },
+    iframe: {
+      display: "block",
+      border: "none",
+      height: "30px",
+      width: "100%",
+      ...(style || {}),
+    },
+  };
+};

--- a/src/features/payment/components/IframeCardForm/IframeCardField.tsx
+++ b/src/features/payment/components/IframeCardForm/IframeCardField.tsx
@@ -1,4 +1,10 @@
-import { Box, FormControl, FormHelperText, InputLabel } from "@mui/material";
+import {
+  Box,
+  FormControl,
+  FormHelperText,
+  InputLabel,
+  useTheme,
+} from "@mui/material";
 import { SxProps } from "@mui/system";
 import React from "react";
 import { useTranslation } from "react-i18next";
@@ -67,19 +73,13 @@ export function RenderField(props: Props) {
   );
 }
 
-const COLORS = {
-  LABEL: "#5c6f82",
-  BOX: "#c4c4c4",
-  VALID: "#0073e6",
-  INVALID: "#d85757",
-  HOVER: "#17324D",
-};
-
 // Function to calculate border styles based on validity
-const borderStyles = (isValid: boolean | undefined) => {
+const useBorderStyles = (isValid: boolean | undefined) => {
+  const { palette } = useTheme();
+
   // If validity is defined, determine colors for valid or invalid state
   if (isValid !== undefined) {
-    const validityColor = isValid ? COLORS.VALID : COLORS.INVALID;
+    const validityColor = isValid ? palette.primary.main : palette.error.dark;
     return {
       labelColor: validityColor,
       boxColor: validityColor,
@@ -90,15 +90,15 @@ const borderStyles = (isValid: boolean | undefined) => {
 
   // Default styles for undefined validity (neutral state)
   return {
-    labelColor: COLORS.LABEL,
-    boxColor: COLORS.BOX,
+    labelColor: palette.text.secondary,
+    boxColor: palette.grey[500],
     hoverShadowWidth: "1px",
-    hoverShadowColor: COLORS.HOVER,
+    hoverShadowColor: palette.text.primary,
   };
 };
 
 const useStyles = ({ isValid, style }: Props): Styles => {
-  const borderStyle = borderStyles(isValid);
+  const borderStyle = useBorderStyles(isValid);
 
   return {
     formControl: {

--- a/src/features/payment/components/IframeCardForm/IframeCardForm.tsx
+++ b/src/features/payment/components/IframeCardForm/IframeCardForm.tsx
@@ -29,6 +29,8 @@ import { useAppDispatch } from "../../../../redux/hooks/hooks";
 import { setThreshold } from "../../../../redux/slices/threshold";
 import { RenderField } from "./IframeCardField";
 import { CreateSessionResponse } from "../../../../../generated/definitions/payment-ecommerce/CreateSessionResponse";
+import type { FieldFormStatus, FieldsFormStatus } from "./types";
+import { IdFields } from "./types";
 
 interface Props {
   loading?: boolean;
@@ -37,29 +39,15 @@ interface Props {
   hideCancel?: boolean;
 }
 
-interface FieldFormStatus {
-  isValid: boolean;
-  errorCode: null | string;
-  errorMessage: null | string;
-}
-
-export enum IdFields {
-  "CARD_NUMBER" = "CARD_NUMBER",
-  "EXPIRATION_DATE" = "EXPIRATION_DATE",
-  "SECURITY_CODE" = "SECURITY_CODE",
-  "CARDHOLDER_NAME" = "CARDHOLDER_NAME",
-}
-type FieldsFormStatus = Map<keyof typeof IdFields | string, FieldFormStatus>;
-
 const initialFormStatus: FieldFormStatus = {
-  isValid: false,
+  isValid: undefined,
   errorCode: null,
   errorMessage: null,
 };
 
-const fieldformStatus: FieldsFormStatus = new Map();
+const fieldFormStatus: FieldsFormStatus = new Map();
 Object.values(IdFields).forEach((k) => {
-  fieldformStatus.set(k as keyof typeof IdFields, initialFormStatus);
+  fieldFormStatus.set(k as keyof typeof IdFields, initialFormStatus);
 });
 
 // eslint-disable-next-line sonarjs/cognitive-complexity
@@ -79,8 +67,8 @@ export default function IframeCardForm(props: Props) {
   const [buildInstance, setBuildInstance] = React.useState();
 
   const calculateFormValidStatus = (
-    fieldformStatus: Map<string, FieldFormStatus>
-  ) => Array.from(fieldformStatus.values()).every((el) => el.isValid);
+    fieldFormStatus: Map<string, FieldFormStatus>
+  ) => Array.from(fieldFormStatus.values()).every((el) => el.isValid);
 
   const onError = (m: string) => {
     setLoading(false);
@@ -192,12 +180,12 @@ export default function IframeCardForm(props: Props) {
             const { id } = evtData;
             // write some code to manage the successful data entering in the specifiedfield: evtData.id
             if (Object.keys(IdFields).includes(id)) {
-              fieldformStatus.set(id as unknown as keyof typeof IdFields, {
+              fieldFormStatus.set(id as unknown as keyof typeof IdFields, {
                 isValid: true,
                 errorCode: null,
                 errorMessage: null,
               });
-              setEnabledForm(calculateFormValidStatus(fieldformStatus));
+              setEnabledForm(calculateFormValidStatus(fieldFormStatus));
               setDummyState(Math.random);
             }
           },
@@ -219,12 +207,12 @@ export default function IframeCardForm(props: Props) {
             //   HF0009 –3DS GDI verification failed –the payment experience has to be stopped with failure.
             const { id, errorCode, errorMessage } = evtData;
             if (Object.keys(IdFields).includes(id)) {
-              fieldformStatus.set(id as unknown as keyof typeof IdFields, {
+              fieldFormStatus.set(id as unknown as keyof typeof IdFields, {
                 isValid: false,
                 errorCode,
                 errorMessage,
               });
-              setEnabledForm(calculateFormValidStatus(fieldformStatus));
+              setEnabledForm(calculateFormValidStatus(fieldFormStatus));
               setDummyState(Math.random);
             }
           },
@@ -308,10 +296,11 @@ export default function IframeCardForm(props: Props) {
                   label={t("inputCardPage.formFields.number")}
                   fields={form?.paymentMethodData.form}
                   id={"CARD_NUMBER"}
-                  errorCode={fieldformStatus.get("CARD_NUMBER")?.errorCode}
+                  errorCode={fieldFormStatus.get("CARD_NUMBER")?.errorCode}
                   errorMessage={
-                    fieldformStatus.get("CARD_NUMBER")?.errorMessage
+                    fieldFormStatus.get("CARD_NUMBER")?.errorMessage
                   }
+                  isValid={fieldFormStatus.get("CARD_NUMBER")?.isValid}
                 />
               </Box>
               <Box
@@ -325,11 +314,12 @@ export default function IframeCardForm(props: Props) {
                     fields={form?.paymentMethodData.form}
                     id={"EXPIRATION_DATE"}
                     errorCode={
-                      fieldformStatus.get("EXPIRATION_DATE")?.errorCode
+                      fieldFormStatus.get("EXPIRATION_DATE")?.errorCode
                     }
                     errorMessage={
-                      fieldformStatus.get("EXPIRATION_DATE")?.errorMessage
+                      fieldFormStatus.get("EXPIRATION_DATE")?.errorMessage
                     }
+                    isValid={fieldFormStatus.get("EXPIRATION_DATE")?.isValid}
                   />
                 </Box>
                 <Box>
@@ -337,10 +327,11 @@ export default function IframeCardForm(props: Props) {
                     label={t("inputCardPage.formFields.cvv")}
                     fields={form?.paymentMethodData.form}
                     id={"SECURITY_CODE"}
-                    errorCode={fieldformStatus.get("SECURITY_CODE")?.errorCode}
+                    errorCode={fieldFormStatus.get("SECURITY_CODE")?.errorCode}
                     errorMessage={
-                      fieldformStatus.get("SECURITY_CODE")?.errorMessage
+                      fieldFormStatus.get("SECURITY_CODE")?.errorMessage
                     }
+                    isValid={fieldFormStatus.get("SECURITY_CODE")?.isValid}
                   />
                 </Box>
               </Box>
@@ -349,10 +340,11 @@ export default function IframeCardForm(props: Props) {
                   label={t("inputCardPage.formFields.name")}
                   fields={form?.paymentMethodData.form}
                   id={"CARDHOLDER_NAME"}
-                  errorCode={fieldformStatus.get("CARDHOLDER_NAME")?.errorCode}
+                  errorCode={fieldFormStatus.get("CARDHOLDER_NAME")?.errorCode}
                   errorMessage={
-                    fieldformStatus.get("CARDHOLDER_NAME")?.errorMessage
+                    fieldFormStatus.get("CARDHOLDER_NAME")?.errorMessage
                   }
+                  isValid={fieldFormStatus.get("CARDHOLDER_NAME")?.isValid}
                 />
               </Box>
             </Box>

--- a/src/features/payment/components/IframeCardForm/IframeCardForm.tsx
+++ b/src/features/payment/components/IframeCardForm/IframeCardForm.tsx
@@ -27,7 +27,7 @@ import { CalculateFeeResponse } from "../../../../../generated/definitions/payme
 import { ErrorsType } from "../../../../utils/errors/checkErrorsModel";
 import { useAppDispatch } from "../../../../redux/hooks/hooks";
 import { setThreshold } from "../../../../redux/slices/threshold";
-import { RenderField } from "./IframeCardField";
+import { IframeCardField } from "./IframeCardField";
 import { CreateSessionResponse } from "../../../../../generated/definitions/payment-ecommerce/CreateSessionResponse";
 import type { FieldFormStatus, FieldsFormStatus } from "./types";
 import { IdFields } from "./types";
@@ -60,7 +60,7 @@ export default function IframeCardForm(props: Props) {
   const [spinner, setSpinner] = React.useState(loading);
   const [enabledForm, setEnabledForm] = React.useState(false);
   const ref = React.useRef<ReCAPTCHA>(null);
-  // this dummy state is only used to permorm a component udpate, not the best solution but works
+  // this dummy state is only used to perform a component update, not the best solution but works
   const [, setDummyState] = React.useState(0);
   const dispatch = useAppDispatch();
 
@@ -178,7 +178,7 @@ export default function IframeCardForm(props: Props) {
         const newBuild = new Build({
           onBuildSuccess(evtData: { id: keyof typeof IdFields }) {
             const { id } = evtData;
-            // write some code to manage the successful data entering in the specifiedfield: evtData.id
+            // write some code to manage the successful data entering in the specified field: evtData.id
             if (Object.keys(IdFields).includes(id)) {
               fieldFormStatus.set(id as unknown as keyof typeof IdFields, {
                 isValid: true,
@@ -292,7 +292,7 @@ export default function IframeCardForm(props: Props) {
           <form id="iframe-card-form" onSubmit={handleSubmit}>
             <Box>
               <Box>
-                <RenderField
+                <IframeCardField
                   label={t("inputCardPage.formFields.number")}
                   fields={form?.paymentMethodData.form}
                   id={"CARD_NUMBER"}
@@ -309,7 +309,7 @@ export default function IframeCardForm(props: Props) {
                 sx={{ gap: 2 }}
               >
                 <Box>
-                  <RenderField
+                  <IframeCardField
                     label={t("inputCardPage.formFields.expirationDate")}
                     fields={form?.paymentMethodData.form}
                     id={"EXPIRATION_DATE"}
@@ -323,7 +323,7 @@ export default function IframeCardForm(props: Props) {
                   />
                 </Box>
                 <Box>
-                  <RenderField
+                  <IframeCardField
                     label={t("inputCardPage.formFields.cvv")}
                     fields={form?.paymentMethodData.form}
                     id={"SECURITY_CODE"}
@@ -336,7 +336,7 @@ export default function IframeCardForm(props: Props) {
                 </Box>
               </Box>
               <Box>
-                <RenderField
+                <IframeCardField
                   label={t("inputCardPage.formFields.name")}
                   fields={form?.paymentMethodData.form}
                   id={"CARDHOLDER_NAME"}

--- a/src/features/payment/components/IframeCardForm/types.ts
+++ b/src/features/payment/components/IframeCardForm/types.ts
@@ -1,0 +1,17 @@
+export type FieldsFormStatus = Map<
+  keyof typeof IdFields | string,
+  FieldFormStatus
+>;
+
+export interface FieldFormStatus {
+  isValid?: boolean;
+  errorCode: null | string;
+  errorMessage: null | string;
+}
+
+export enum IdFields {
+  CARD_NUMBER = "CARD_NUMBER",
+  EXPIRATION_DATE = "EXPIRATION_DATE",
+  SECURITY_CODE = "SECURITY_CODE",
+  CARDHOLDER_NAME = "CARDHOLDER_NAME",
+}


### PR DESCRIPTION
This commit tries to reproduce the border ux of @mui `TextField` component.

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- Structured styling for the `RenderField` component
- Extracted border styles calculation
- Extracted typing to types file

#### Motivation and Context

Using the embedded npg payment frames prevents the use of the TextField mui component used in forms of other payment pages.

#### How Has This Been Tested?

Visual testing

#### Screenshots (if appropriate):
![image](https://github.com/pagopa/pagopa-checkout-fe/assets/61319404/2d1f45a6-4168-41dd-b52c-e92d5d4905c6)

![image](https://github.com/pagopa/pagopa-checkout-fe/assets/61319404/5f9b56ba-43d3-4ab0-b0e1-6b795b4fb0de)

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
