### PR TITLE
[CHK-1826] fix card form duplication

### DIFF
--- a/src/features/payment/components/PaymentChoice/PaymentChoice.tsx
+++ b/src/features/payment/components/PaymentChoice/PaymentChoice.tsx
@@ -2,7 +2,6 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 /* eslint-disable functional/immutable-data */
 import React from "react";
-import { useNavigate } from "react-router";
 import ClickableFieldContainer from "../../../../components/TextFormField/ClickableFieldContainer";
 import {
   PaymentMethodRoutes,
@@ -58,8 +57,6 @@ export function PaymentChoice(props: {
   paymentInstruments: Array<PaymentInstruments>;
   loading?: boolean;
 }) {
-  const navigate = useNavigate();
-
   const handleClickOnMethod = React.useCallback(
     (paymentType: TransactionMethods, paymentMethodId: string) => {
       const route: string = PaymentMethodRoutes[paymentType]?.route;
@@ -79,7 +76,8 @@ export function PaymentChoice(props: {
           });
         },
       }); */
-      navigate(`/${route}`);
+
+      window.location.assign(`/${route}`);
     },
     []
   );

--- a/src/routes/PaymentCheckPage.tsx
+++ b/src/routes/PaymentCheckPage.tsx
@@ -172,6 +172,11 @@ export default function PaymentCheckPage() {
     }
   }, []);
 
+  const onCardEdit = () => {
+    window.removeEventListener("beforeunload", onBrowserUnload);
+    window.location.replace(`/${CheckoutRoutes.INSERISCI_CARTA}`);
+  };
+
   const onCancel = React.useCallback(() => {
     setCancelModalOpen(true);
   }, []);
@@ -274,7 +279,7 @@ export default function PaymentCheckPage() {
         endAdornment={
           <Button
             variant="text"
-            onClick={() => navigate(`/${CheckoutRoutes.INSERISCI_CARTA}`)}
+            onClick={onCardEdit}
             startIcon={<EditIcon />}
             disabled={isDisabled()}
             aria-label={t("ariaLabels.editCard")}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
- payment choice page uses location assign to navigate to card data page 
- payment check page removes `beforeunload` listener before navigating back to card data page
- payment check page uses location replace to navigate back to card data page 

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Use location replace or assign instead of router-dom navigate so to
cause a window reload and cleaning the window from frames
loaded by previous npg sdk builds

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Visual testing

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
