### PR TITLE
[CHK-1912] iFrameCardForm Skeleton

### DIFF
--- a/src/features/payment/components/IframeCardForm/IframeCardField.tsx
+++ b/src/features/payment/components/IframeCardForm/IframeCardField.tsx
@@ -81,7 +81,7 @@ export function IframeCardField(props: Props) {
           style={styles.fieldStatusIcon}
           visibility={isValid === false ? "visible" : "hidden"}
         >
-          <ErrorOutlineIcon sx={{ mr: 1 }} color="error" />
+          <ErrorOutlineIcon sx={{ mr: 2.5 }} color="error" />
         </Box>
       </Box>
       {(errorMessage || errorCode) && (
@@ -164,9 +164,11 @@ const useStyles = (props: Props): Styles => {
     },
     fieldStatusIcon: {
       display: "flex",
+      position: "absolute",
       alignItems: "center",
-      width: "10%",
-      justifyContent: "flex-end",
+      width: "10%%",
+      justifySelf: "flex-end",
+      cursor: "initial",
     },
   };
 };
@@ -201,7 +203,7 @@ const useBorderStyles = ({ isValid, activeField, id }: Props) => {
   return {
     labelColor: isValid ? palette.text.secondary : errorColor,
     boxColor: isValid ? palette.grey[500] : errorColor,
-    hoverShadowWidth: "1px",
+    hoverShadowWidth: "2px",
     hoverShadowColor: isValid ? palette.text.primary : errorColor,
   };
 };

--- a/src/features/payment/components/IframeCardForm/IframeCardField.tsx
+++ b/src/features/payment/components/IframeCardForm/IframeCardField.tsx
@@ -64,11 +64,12 @@ export function IframeCardField(props: Props) {
         sx={styles.label}
         margin="dense"
         shrink
-        htmlFor={`frame_${id}`}
+        htmlFor={id}
+        id={label}
       >
         {label}
       </InputLabel>
-      <Box sx={styles.box}>
+      <Box sx={styles.box} aria-busy={!loaded}>
         <iframe
           aria-labelledby={label}
           id={`frame_${id}`}
@@ -79,6 +80,7 @@ export function IframeCardField(props: Props) {
         />
         <Box
           style={styles.fieldStatusIcon}
+          role="presentation"
           visibility={isValid === false ? "visible" : "hidden"}
         >
           <ErrorOutlineIcon sx={{ mr: 2.5 }} color="error" />
@@ -106,6 +108,7 @@ export function IframeCardField(props: Props) {
         <Skeleton
           variant="text"
           sx={styles.skeleton}
+          aria-busy={true}
           animation="wave"
         >
           {InnerComponent}

--- a/src/features/payment/components/IframeCardForm/IframeCardForm.tsx
+++ b/src/features/payment/components/IframeCardForm/IframeCardForm.tsx
@@ -59,7 +59,6 @@ export default function IframeCardForm(props: Props) {
   const { onCancel, hideCancel } = props;
   const [errorModalOpen, setErrorModalOpen] = React.useState(false);
   const [loading, setLoading] = React.useState(false);
-  const [spinner, setSpinner] = React.useState(true);
   const [error, setError] = React.useState("");
   const [form, setForm] = React.useState<CreateSessionResponse>();
   const [activeField, setActiveField] = React.useState<FieldId | undefined>(
@@ -77,7 +76,6 @@ export default function IframeCardForm(props: Props) {
 
   const onError = (m: string) => {
     setLoading(false);
-    setSpinner(false);
     setError(m);
     setErrorModalOpen(true);
     ref.current?.reset();
@@ -183,7 +181,6 @@ export default function IframeCardForm(props: Props) {
   React.useEffect(() => {
     if (!form) {
       const onResponse = (body: CreateSessionResponse) => {
-        setSpinner(true);
         setSessionItem(SessionItems.orderId, body.orderId);
         setForm(body);
 
@@ -201,7 +198,6 @@ export default function IframeCardForm(props: Props) {
 
         const onBuildError = () => {
           setLoading(false);
-          setSpinner(false);
           window.location.replace(`/${CheckoutRoutes.ERRORE}`);
         };
 
@@ -219,7 +215,6 @@ export default function IframeCardForm(props: Props) {
             })
           );
           setBuildInstance(newBuild);
-          setSpinner(false);
         } catch {
           onBuildError();
         }
@@ -246,7 +241,6 @@ export default function IframeCardForm(props: Props) {
     <>
       <form id="iframe-card-form" onSubmit={handleSubmit}>
         <Box>
-          {spinner && "spinner"}
           <Box>
             <IframeCardField
               label={t("inputCardPage.formFields.number")}

--- a/src/utils/buildConfig.ts
+++ b/src/utils/buildConfig.ts
@@ -18,6 +18,11 @@ interface BuildConfig {
 
 export default (buildConfig: BuildConfig) => {
   const { hostname, protocol, port } = window.location;
+
+  const cssPath = `${protocol}//${hostname}${
+    process.env.NODE_ENV === "development" ? `:${port}` : ""
+  }/npg/style.css`;
+
   const {
     onBuildError,
     onChange,
@@ -88,9 +93,7 @@ export default (buildConfig: BuildConfig) => {
           onBuildError();
       }
     },
-    cssLink: `${protocol}//${hostname}${
-      process.env.NODE_ENV === "development" ? `:${port}` : ""
-    }/npg/style.css`,
+    cssLink: cssPath,
     defaultComponentCssClassName: "npg-component",
     defaultContainerCssClassName: "npg-container",
     // any dependency will initialize the build instance more than one time

--- a/static/normalize.css
+++ b/static/normalize.css
@@ -149,28 +149,28 @@ template {
   font-family: "Titillium Web";
   font-style: normal;
   font-weight: 400;
-  src: url("../fonts/TitilliumWeb-Regular.ttf") format("truetype");
+  src: url("./fonts/TitilliumWeb-Regular.ttf") format("truetype");
 }
 
 @font-face {
   font-family: "Titillium Web";
   font-style: italic;
   font-weight: 400;
-  src: url("../fonts/TitilliumWeb-Italic.ttf") format("truetype");
+  src: url("./fonts/TitilliumWeb-Italic.ttf") format("truetype");
 }
 
 @font-face {
   font-family: "Titillium Web";
   font-style: normal;
   font-weight: 600;
-  src: url("../fonts/TitilliumWeb-SemiBold.ttf") format("truetype");
+  src: url("./fonts/TitilliumWeb-SemiBold.ttf") format("truetype");
 }
 
 @font-face {
   font-family: "Titillium Web";
   font-style: italic;
   font-weight: 600;
-  src: url("../fonts/TitilliumWeb-SemiBoldItalic.ttf") format("truetype");
+  src: url("./fonts/TitilliumWeb-SemiBoldItalic.ttf") format("truetype");
 }
 html {
   font-family: "Titillium Web";

--- a/static/npg/style.css
+++ b/static/npg/style.css
@@ -1,10 +1,18 @@
 @import  '../normalize.css';
 
-body {
+* {
 	height: 100%;
 	width: 100%;
 	padding: 0;
 	margin: 0;
+
+}
+
+body {
+	margin: 0;
+	padding: 0;
+	height: 100%;
+	width: 100%;
 }
 
 .npg-container {
@@ -28,11 +36,6 @@ body {
 	width: 100%;
 	position: relative;
 	font-weight: 600;
-}
-
-.npg-container, div {
-  width: 100%;
-	height: 100%;
 }
 
 .npg-component {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- Material ui skeleton showed for 2s before displaying the card data form
- Improved style and npg css to extend the input area to the full box wrapper size
- Fixed adornment aria role attribute

<!--- Describe your changes in detail -->

#### Motivation and Context

This pr tries to reduce the flash of unstyled content while the npg iframes are loading the css.
Since is not possible to know exactly when the iframes are fully loaded, a 2s timeout is used.
  
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

- Visual testing
- Linux screen reader (a11y)
- Axe dev-tools (a11y)

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):
![image](https://github.com/pagopa/pagopa-checkout-fe/assets/61319404/6c9b0c0b-1c71-4ece-985f-0a79fefaa2ad)

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
