### PR TITLE
[CHK-1943] Card data form bug: removing duplicated iframe fields during skeleton loading phase

### DIFF
--- a/src/features/payment/components/IframeCardForm/IframeCardField.tsx
+++ b/src/features/payment/components/IframeCardForm/IframeCardField.tsx
@@ -110,9 +110,7 @@ export function IframeCardField(props: Props) {
           sx={styles.skeleton}
           aria-busy={true}
           animation="wave"
-        >
-          {InnerComponent}
-        </Skeleton>
+        />
       )}
       <Box display={loaded ? "flex" : "none"}>{InnerComponent}</Box>
     </>
@@ -164,6 +162,7 @@ const useStyles = (props: Props): Styles => {
       width: "100%",
       maxWidth: "100%",
       cursor: "progress",
+      height: "108px",
     },
     fieldStatusIcon: {
       display: "flex",

--- a/src/features/payment/components/IframeCardForm/IframeCardForm.tsx
+++ b/src/features/payment/components/IframeCardForm/IframeCardForm.tsx
@@ -257,7 +257,7 @@ export default function IframeCardForm(props: Props) {
             justifyContent={"space-between"}
             sx={{ gap: 2 }}
           >
-            <Box width="50%">
+            <Box sx={{ flex: "1 1 0" }}>
               <IframeCardField
                 label={t("inputCardPage.formFields.expirationDate")}
                 fields={form?.paymentMethodData.form}

--- a/src/features/payment/components/IframeCardForm/IframeCardForm.tsx
+++ b/src/features/payment/components/IframeCardForm/IframeCardForm.tsx
@@ -257,7 +257,7 @@ export default function IframeCardForm(props: Props) {
             justifyContent={"space-between"}
             sx={{ gap: 2 }}
           >
-            <Box>
+            <Box width="50%">
               <IframeCardField
                 label={t("inputCardPage.formFields.expirationDate")}
                 fields={form?.paymentMethodData.form}
@@ -268,7 +268,7 @@ export default function IframeCardForm(props: Props) {
                 activeField={activeField}
               />
             </Box>
-            <Box>
+            <Box width="50%">
               <IframeCardField
                 label={t("inputCardPage.formFields.cvv")}
                 fields={form?.paymentMethodData.form}


### PR DESCRIPTION
#### List of Changes
I have simply removed the iframe field during the loading phase giving to the skeleton the right dimensions

<!--- Describe your changes in detail -->

#### Motivation and Context
Just one instance of every iframe field is needed to trigger Nexi sdk events correctly

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Tested locally using the BE mock as back-end service

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
