### PR TITLE
[#CHK-1895]  add recaptcha to sessions transactions

### DIFF
--- a/src/routes/IframeCardPage.tsx
+++ b/src/routes/IframeCardPage.tsx
@@ -1,16 +1,11 @@
 import { Box } from "@mui/material";
 import React from "react";
-import ReCAPTCHA from "react-google-recaptcha";
 import { useNavigate } from "react-router-dom";
 import * as E from "fp-ts/Either";
 import { pipe } from "fp-ts/function";
 import PageContainer from "../components/PageContent/PageContainer";
 import IframeCardForm from "../features/payment/components/IframeCardForm/IframeCardForm";
-import {
-  getReCaptchaKey,
-  getSessionItem,
-  SessionItems,
-} from "../utils/storage/sessionStorage";
+import { getSessionItem, SessionItems } from "../utils/storage/sessionStorage";
 import { NewTransactionResponse } from "../../generated/definitions/payment-ecommerce/NewTransactionResponse";
 
 export default function IFrameCardPage() {
@@ -21,7 +16,6 @@ export default function IFrameCardPage() {
   // Is It allowed to store the bin temporary?
   // const [bin, setBin] = React.useState("");
   const [hideCancelButton, setHideCancelButton] = React.useState(false);
-  const ref = React.useRef<ReCAPTCHA>(null);
   // const dispatch = useAppDispatch();
 
   React.useEffect(() => {
@@ -45,13 +39,6 @@ export default function IFrameCardPage() {
           onCancel={onCancel}
           hideCancel={hideCancelButton}
           loading={loading}
-        />
-      </Box>
-      <Box display="none">
-        <ReCAPTCHA
-          ref={ref}
-          size="invisible"
-          sitekey={getReCaptchaKey() as string}
         />
       </Box>
     </PageContainer>

--- a/src/utils/api/helper.ts
+++ b/src/utils/api/helper.ts
@@ -1070,7 +1070,8 @@ const expDateToString = (dateParsed: Date) =>
 
 export const npgSessionsFields = async (
   onError: (e: string) => void,
-  onResponse: (data: CreateSessionResponse) => void
+  onResponse: (data: CreateSessionResponse) => void,
+  recaptchaResponse: string
 ) =>
   await pipe(
     TE.tryCatch(
@@ -1086,6 +1087,7 @@ export const npgSessionsFields = async (
           )?.paymentMethodId || "";
         return apiPaymentEcommerceClientWithRetry.createSession({
           id: paymentMethodId,
+          recaptchaResponse,
         });
       },
       () => {


### PR DESCRIPTION

This PR adds recaptcha check to the "sessions" and "transactions" calls.
Depends on [this PR](https://github.com/pagopa/pagopa-checkout-be-mock/pull/63)

#### List of Changes

- added recaptcha
- refact recaptcha init


#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
