### PR TITLE
[CHK-2138] Back button bug's

### DIFF
--- a/src/features/payment/components/IframeCardForm/IframeCardField.tsx
+++ b/src/features/payment/components/IframeCardForm/IframeCardField.tsx
@@ -49,12 +49,21 @@ export function IframeCardField(props: Props) {
   const [loaded, setLoaded] = React.useState<State["loaded"]>(false);
   const styles = useStyles(props);
 
+  // function to set SRC to the iframe el avoind firefox back button bug
+  const setSrcOnIframe = (src: string) => {
+    const iframeEl: HTMLIFrameElement | null = document.getElementById(
+      `frame_${id}`
+    ) as HTMLIFrameElement;
+    iframeEl?.contentWindow?.location.replace(src);
+    setLoaded(true);
+  };
+
   // Find src based on ID
   const src = fields && id ? getSrcFromFieldsByID(fields, id) : "";
 
   React.useEffect(() => {
     if (src) {
-      setTimeout(() => setLoaded(true), 2000);
+      setTimeout(() => setSrcOnIframe(src), 2000);
     }
   }, [src]);
 
@@ -75,7 +84,6 @@ export function IframeCardField(props: Props) {
           id={`frame_${id}`}
           loading="lazy"
           seamless
-          src={src}
           style={styles.iframe}
         />
         <Box


### PR DESCRIPTION
This PR try to solve the bug listed using a `location.replace` directive instead of the use of "src attribute".
Firefox only at the pressure of the back button try "to back" the iframe instead the main page.

#### List of Changes
- write a function to populate the form source via _location_

#### Motivation and Context

Solve the bug

#### How Has This Been Tested?

- visual/manual testing

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
