### PR TITLE
[CHK-2142] Redirect instead reload when miss Threshold

### DIFF
--- a/src/routes/PaymentCheckPage.tsx
+++ b/src/routes/PaymentCheckPage.tsx
@@ -138,7 +138,7 @@ export default function PaymentCheckPage() {
 
   React.useEffect(() => {
     if (missingThreshold()) {
-      onError(ErrorsType.GENERIC_ERROR);
+      onCardEdit();
     }
   }, [threshold]);
 


### PR DESCRIPTION
When a user refresh the check payment page, we've to redirect him to the previous page instead show an error (caused by the missing of threshold value stored in redux)

#### List of Changes

- put a redirect in the miss `if` 

#### Motivation and Context

Solve the bug

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
