### PR TITLE
[#CHK-2214] Set false if card is not on us

### DIFF
--- a/src/routes/PaymentCheckPage.tsx
+++ b/src/routes/PaymentCheckPage.tsx
@@ -104,6 +104,9 @@ export default function PaymentCheckPage() {
     ) + Number(pspSelected?.taxPayerFee || 0);
 
   React.useEffect(() => {
+    if (!pspSelected?.onUs) {
+      setShowDisclaimer(false);
+    }
     const onBrowserBackEvent = (e: any) => {
       e.preventDefault();
       window.history.pushState(null, "", window.location.pathname);


### PR DESCRIPTION
This PR fixes the bug #CHK-2214 setting "false" the show of the disclaimer in the checkpage qhen the method is not "on us"

#### List of Changes

- set false when not on us

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
