### PR TITLE
[CHK-2225] Psps logo height

### DIFF
--- a/src/components/TextFormField/PspFieldContainer.tsx
+++ b/src/components/TextFormField/PspFieldContainer.tsx
@@ -52,9 +52,10 @@ function PspFieldContainer(props: {
           }}
         >
           <img
-            src={props.image}
             alt="Logo gestore"
-            style={{ maxWidth: "80%" }}
+            aria-hidden="true"
+            src={props.image}
+            style={{ maxWidth: "80%", maxHeight: "32px", width: "auto" }}
           />
           <Typography
             variant={props.bodyVariant}


### PR DESCRIPTION
This fix try to harmonize the PSPs list with a max height of logos

#### List of Changes
- add max height to imgs

#### Motivation and Context

Fix the bug 2225


#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
