### PR TITLE
[#CHK-2594] Click on a payment method

### DIFF
--- a/src/features/payment/components/PaymentChoice/PaymentChoice.tsx
+++ b/src/features/payment/components/PaymentChoice/PaymentChoice.tsx
@@ -24,7 +24,7 @@ const sortMethods = (a: PaymentInstrumentsType, b: PaymentInstrumentsType) => {
   } else if (shouldBeFirst(b)) {
     return 1;
   }
-  return a.name.localeCompare(b.name);
+  return a.description.localeCompare(b.description);
 };
 
 const getNormalizedMethods = (

--- a/src/features/payment/components/PaymentChoice/PaymentChoice.tsx
+++ b/src/features/payment/components/PaymentChoice/PaymentChoice.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import mixpanel from "mixpanel-browser";
+import { mixpanel } from "../../../../utils/config/mixpanelHelperInit";
 import ClickableFieldContainer from "../../../../components/TextFormField/ClickableFieldContainer";
 import { PaymentMethodRoutes } from "../../../../routes/models/paymentMethodRoutes";
 import {
@@ -80,8 +80,7 @@ export function PaymentChoice(props: {
         paymentTypeCode,
       });
       mixpanel.track(PAYMENT_METHODS_CHOICE.value, {
-        EVENT_ID: PAYMENT_METHODS_CHOICE.value,
-        paymentTypeCode,
+        EVENT_ID: paymentTypeCode,
       });
 
       window.location.assign(`/${route}`);

--- a/src/features/payment/components/PaymentChoice/PaymentMethod.tsx
+++ b/src/features/payment/components/PaymentChoice/PaymentMethod.tsx
@@ -140,7 +140,7 @@ const MethodComponent = ({
   <ClickableFieldContainer
     dataTestId={testable ? method.paymentTypeCode : undefined}
     dataTestLabel={testable ? "payment-method" : undefined}
-    title={method.name}
+    title={method.description}
     onClick={onClick}
     icon={<ImageComponent {...method} />}
     endAdornment={


### PR DESCRIPTION
The bug occur when a user try to select a payment method obtaining an errore instead a redirect to a page.

#### List of Changes

- Print the description value instead the name
- import the correct utility to track the selection of a method

#### Motivation and Context

Solve the bug

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
