### PR TITLE
[CHK-2611] Drop laxyloading attribute from npg iframe

### DIFF
--- a/src/features/payment/components/IframeCardForm/IframeCardField.tsx
+++ b/src/features/payment/components/IframeCardForm/IframeCardField.tsx
@@ -82,7 +82,6 @@ export function IframeCardField(props: Props) {
         <iframe
           aria-labelledby={label}
           id={`frame_${id}`}
-          loading="lazy"
           seamless
           style={styles.iframe}
         />


### PR DESCRIPTION
This PR solve a problem on Firefox browser.

#### List of Changes

- drop lazy attribute from `iframe` 

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
