### PR TITLE
[CHK-2622] use card remote icon

### DIFF
--- a/src/features/payment/components/PaymentChoice/PaymentMethod.tsx
+++ b/src/features/payment/components/PaymentChoice/PaymentMethod.tsx
@@ -8,12 +8,8 @@ import {
 } from "@mui/material";
 import * as React from "react";
 import { useTranslation } from "react-i18next";
-import CreditCardIcon from "@mui/icons-material/CreditCard";
 import ClickableFieldContainer from "../../../../components/TextFormField/ClickableFieldContainer";
-import {
-  PaymentCodeTypeEnum,
-  PaymentInstrumentsType,
-} from "../../models/paymentModel";
+import { PaymentInstrumentsType } from "../../models/paymentModel";
 import { PaymentMethodStatusEnum } from "../../../../../generated/definitions/payment-ecommerce/PaymentMethodStatus";
 import { ImageComponent } from "./PaymentMethodImage";
 

--- a/src/features/payment/components/PaymentChoice/PaymentMethod.tsx
+++ b/src/features/payment/components/PaymentChoice/PaymentMethod.tsx
@@ -79,31 +79,19 @@ const MethodComponent = ({
   method: PaymentInstrumentsType;
   onClick?: () => void;
   testable?: boolean;
-}) => {
-  const iconOrNot =
-    method.paymentTypeCode === PaymentCodeTypeEnum.CP ? (
-      <CreditCardIcon color="primary" fontSize="small" />
-    ) : (
-      <ImageComponent {...method} />
-    );
-
-  return (
-    <ClickableFieldContainer
-      dataTestId={testable ? method.paymentTypeCode : undefined}
-      dataTestLabel={testable ? "payment-method" : undefined}
-      title={method.description}
-      onClick={onClick}
-      icon={<ImageComponent {...method} />}
-      endAdornment={
-        method.status === PaymentMethodStatusEnum.ENABLED && (
-          <ArrowForwardIosIcon
-            sx={{ color: "primary.main" }}
-            fontSize="small"
-          />
-        )
-      }
-      disabled={method.status === PaymentMethodStatusEnum.DISABLED}
-      clickable={method.status === PaymentMethodStatusEnum.ENABLED}
-    />
-  );
-};
+}) => (
+  <ClickableFieldContainer
+    dataTestId={testable ? method.paymentTypeCode : undefined}
+    dataTestLabel={testable ? "payment-method" : undefined}
+    title={method.description}
+    onClick={onClick}
+    icon={<ImageComponent {...method} />}
+    endAdornment={
+      method.status === PaymentMethodStatusEnum.ENABLED && (
+        <ArrowForwardIosIcon sx={{ color: "primary.main" }} fontSize="small" />
+      )
+    }
+    disabled={method.status === PaymentMethodStatusEnum.DISABLED}
+    clickable={method.status === PaymentMethodStatusEnum.ENABLED}
+  />
+);

--- a/src/features/payment/components/PaymentChoice/PaymentMethod.tsx
+++ b/src/features/payment/components/PaymentChoice/PaymentMethod.tsx
@@ -93,7 +93,7 @@ const MethodComponent = ({
       dataTestLabel={testable ? "payment-method" : undefined}
       title={method.description}
       onClick={onClick}
-      icon={iconOrNot}
+      icon={<ImageComponent {...method} />}
       endAdornment={
         method.status === PaymentMethodStatusEnum.ENABLED && (
           <ArrowForwardIosIcon


### PR DESCRIPTION
Use card generic png icon also payment method card in place of svg icon

#### List of Changes

Remove svg icon present only for payment method card item in payment method choice page

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

![Screenshot 2024-03-26 alle 15 15 56](https://github.com/pagopa/pagopa-checkout-fe/assets/113357981/7a35edac-9d4e-4808-aa24-89c232f7a7e0)


#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
