### PR TITLE
fix: [CHK-2640] Back loop between select method and insert email

### DIFF
--- a/.devops/pagopa-code-review-pipelines.yml
+++ b/.devops/pagopa-code-review-pipelines.yml
@@ -59,6 +59,7 @@ stages:
             api_payment_activations_basepath: '/checkout/payments/v1'
             pm_host: 'https://acardste.vaservices.eu'
             pm_api_basepath: '/pp-restapi/v4'
+            checkout_version: "$(Build.SourceBranchName):$(Build.SourceVersion)"
 
         - script: |
             yarn build

--- a/src/routes/PaymentChoicePage.tsx
+++ b/src/routes/PaymentChoicePage.tsx
@@ -72,7 +72,7 @@ export default function PaymentChoicePage() {
   }, []);
 
   const handleBackNavigate = React.useCallback(
-    () => navigate(`/${CheckoutRoutes.INSERISCI_EMAIL}`),
+    () => navigate(-1),
     []
   );
 

--- a/src/routes/PaymentChoicePage.tsx
+++ b/src/routes/PaymentChoicePage.tsx
@@ -71,10 +71,7 @@ export default function PaymentChoicePage() {
     onCancelResponse();
   }, []);
 
-  const handleBackNavigate = React.useCallback(
-    () => navigate(-1),
-    []
-  );
+  const handleBackNavigate = React.useCallback(() => navigate(-1), []);
 
   const handleCloseModal = React.useCallback(
     () => setCancelModalOpen(false),


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
The loop between select method page and insert email page when pressing back button is caused by pushing another email page on history stack. The email page use `navigate(-1)` on back press and the previously page is select method when coming from it, so this generate a loop. To solve it, just pop from history stack the select method page to go back to email page.

#### List of Changes

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
