### PR TITLE
[CHK-2745] Stop payment in progress loading after redirect

### DIFF
--- a/src/routes/PaymentCheckPage.tsx
+++ b/src/routes/PaymentCheckPage.tsx
@@ -165,10 +165,10 @@ export default function PaymentCheckPage() {
     }
   };
 
-  const onSubmit = React.useCallback(() => {
+  const onSubmit = React.useCallback(async () => {
     setPayLoading(true);
     if (transaction) {
-      void proceedToPayment(transaction, onError, onResponse);
+      await proceedToPayment(transaction, onError, onResponse);
     } else {
       onError(ErrorsType.GENERIC_ERROR);
     }

--- a/src/routes/PaymentCheckPage.tsx
+++ b/src/routes/PaymentCheckPage.tsx
@@ -150,18 +150,13 @@ export default function PaymentCheckPage() {
     }
   }, [threshold]);
 
-  React.useEffect(() => {
-    const onRedirect = () => setPayLoading(false);
-    window.addEventListener("beforeunload", onRedirect);
-    return () => window.removeEventListener("beforeunload", onRedirect);
-  });
-
   const onResponse = (authorizationUrl: string) => {
     try {
       window.removeEventListener("beforeunload", onBrowserUnload);
       const url = new URL(authorizationUrl);
       if (url.origin === window.location.origin) {
         navigate(`${url.pathname}${url.hash}`);
+        setPayLoading(false);
       } else {
         window.location.replace(url);
       }

--- a/src/routes/PaymentCheckPage.tsx
+++ b/src/routes/PaymentCheckPage.tsx
@@ -150,9 +150,14 @@ export default function PaymentCheckPage() {
     }
   }, [threshold]);
 
+  React.useEffect(() => {
+    const onRedirect = () => setPayLoading(false);
+    window.addEventListener("beforeunload", onRedirect);
+    return () => window.removeEventListener("beforeunload", onRedirect);
+  });
+
   const onResponse = (authorizationUrl: string) => {
     try {
-      setPayLoading(false);
       window.removeEventListener("beforeunload", onBrowserUnload);
       const url = new URL(authorizationUrl);
       if (url.origin === window.location.origin) {

--- a/src/utils/api/helper.ts
+++ b/src/utils/api/helper.ts
@@ -728,7 +728,7 @@ export const proceedToPayment = async (
     })
   );
 
-  void pipe(
+  await pipe(
     authParam,
     O.map((p) =>
       pipe(


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR fix the following issue: after pressing "Pay" the button become unclickable and thats ok. Cause the flag `PayLoading` is set to false before start redirect, the button become clickable, while redirection is loading. This is especially visibile when redirection loading is slow.

I also attempted to use the "beforeunload" event, but it is fired before the redirection is completed and produces the same effect as the bug.

#### List of Changes
- when a payment requires a redirection the flag will not be set to false
- add missing await on async functions

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
