### PR TITLE
Better manage of psp logo's ratio

### DIFF
--- a/src/components/TextFormField/PspFieldContainer.tsx
+++ b/src/components/TextFormField/PspFieldContainer.tsx
@@ -51,12 +51,14 @@ function PspFieldContainer(props: {
             flexDirection: props.flexDirection,
           }}
         >
-          <img
-            alt="Logo gestore"
-            aria-hidden="true"
-            src={props.image}
-            style={{ maxWidth: "80%", maxHeight: "32px", width: "auto" }}
-          />
+          <Box sx={{ width: "80%" }}>
+            <img
+              alt={`Logo ${props.body}`}
+              aria-hidden="true"
+              src={props.image}
+              style={{ maxHeight: "32px", width: "auto" }}
+            />
+          </Box>
           <Typography
             variant={props.bodyVariant}
             component={"div"}


### PR DESCRIPTION
This PR fix a problem with psp logos with a 16:9 ratio

#### List of Changes
- added a container for the img tag

#### Motivation and Context

Solve the bug

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
