### PR TITLE
[CHK-3232] feat(quirk): add recovering of invalidly user-manipulated query parameters

### DIFF
--- a/src/routes/PaymentCartPage.tsx
+++ b/src/routes/PaymentCartPage.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { useNavigate, useParams, useSearchParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
+import { sanitizeSearchParams } from "../utils/quirks/query";
 import ErrorModal from "../components/modals/ErrorModal";
 import CheckoutLoader from "../components/PageContent/CheckoutLoader";
 import { Cart } from "../features/payment/models/paymentModel";
@@ -11,7 +12,7 @@ import { CheckoutRoutes } from "./models/routeModel";
 export default function PaymentCartPage() {
   const navigate = useNavigate();
   const { cartid } = useParams();
-  const [searchParams, _] = useSearchParams();
+  const searchParams = sanitizeSearchParams(window.location.search);
 
   const [errorModalOpen, setErrorModalOpen] = React.useState(false);
   const [error, setError] = React.useState("");

--- a/src/utils/__tests__/quirks/query.test.ts
+++ b/src/utils/__tests__/quirks/query.test.ts
@@ -1,0 +1,24 @@
+import { sanitizeSearchParams } from "../../quirks/query";
+
+describe("Querystring quirks", () => {
+  it("should leave valid search params intact", () => {
+    const validSearchParams = new URLSearchParams({ a: "b", c: "d" });
+    expect(sanitizeSearchParams("?" + validSearchParams.toString())).toEqual(
+      validSearchParams
+    );
+  });
+
+  it("should recover search params with question mark instead of ampersand", () => {
+    const malformedSearchParams = "?foo=bar&quux=jk?aa=bb&cc=dd?ee=ff";
+    const recoveredSearchParams = new URLSearchParams({
+      foo: "bar",
+      quux: "jk",
+      aa: "bb",
+      cc: "dd",
+      ee: "ff",
+    });
+    expect(sanitizeSearchParams(malformedSearchParams)).toEqual(
+      recoveredSearchParams
+    );
+  });
+});

--- a/src/utils/quirks/query.ts
+++ b/src/utils/quirks/query.ts
@@ -1,0 +1,35 @@
+export function sanitizeSearchParams(searchParams: string): URLSearchParams {
+  /*
+   * Note: this function was introduced as part of CHK-3232.
+   * ECs using the `POST /carts` API were manipulating incorrectly the returned redirect URL,
+   * by adding query parameters incorrectly in an form-urlencoded URL and generating a malformed URL that
+   * kept users from being able to use Checkout.
+   * Here we heuristically sanitize the query parameters against invalid modifications and try to recover the
+   * "correct" query parameters. Note that this behaviour is nonstandard.
+   */
+
+  const rawQueryParams = searchParams.slice(1).split("&");
+
+  const sanitizedQueryParams = rawQueryParams
+    .flatMap((p) => p.split("?").map(sanitizeSearchParam))
+    .join("&");
+
+  return new URLSearchParams("?" + sanitizedQueryParams);
+}
+
+function sanitizeSearchParam(searchParam: string) {
+  const reservedCharacters = [";", "/", "?", ":", "@", "&", "=", "+", ",", "$"];
+  const sanitizationMap: Record<string, string> = Object.fromEntries(
+    reservedCharacters.map((c) => [c, encodeURIComponent(c)])
+  );
+
+  // eslint-disable-next-line functional/immutable-data
+  sanitizationMap["?"] = "&"; // special handle stray question marks
+  // eslint-disable-next-line functional/immutable-data
+  sanitizationMap["="] = "="; // leave equal signs intact
+
+  return reservedCharacters.reduce(
+    (result, char) => result.replace(char, sanitizationMap[char]),
+    searchParam
+  );
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
 * add recovering of invalidly user-manipulated query parameters

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This PRs handles a quirk of some users manipulating the redirect URL of Checkout when using eCommerce's `POST /carts` API and expecting an URL with an invalid query string to work.
This PR tries to recover the valid/expected URL to make Checkout work the same.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
