### PR TITLE
fix(WISP_REDIRECT): CHK-3495 payment notice only for subset page wisp redirect

### DIFF
--- a/src/components/Header/DrawerCart.tsx
+++ b/src/components/Header/DrawerCart.tsx
@@ -38,7 +38,7 @@ export default function DrawerCart(props: Props) {
   const cartClientId: string =
     (getSessionItem(SessionItems.cartClientId) as string | undefined) ||
     "CHECKOUT";
-  const isWispRedirecClient = cartClientId === "WISP_REDIRECT";
+  const isWispRedirectClient = cartClientId === "WISP_REDIRECT";
   const isVisiblePaymentNoticeAndFiscaCode =
     !isWispRedirecClient ||
     (isWispRedirecClient && !ignoreRoutesforNoticeNumber.includes(currentPath));

--- a/src/components/Header/DrawerCart.tsx
+++ b/src/components/Header/DrawerCart.tsx
@@ -32,15 +32,16 @@ export default function DrawerCart(props: Props) {
   const ignoreRoutesforNoticeNumber: Array<string> = [
     CheckoutRoutes.INSERISCI_EMAIL,
     CheckoutRoutes.SCEGLI_METODO,
+    CheckoutRoutes.INSERISCI_CARTA,
   ];
-
   const currentPath = location.pathname.split("/").slice(-1)[0];
-
   const cartClientId: string =
     (getSessionItem(SessionItems.cartClientId) as string | undefined) ||
     "CHECKOUT";
-
   const isWispRedirecClient = cartClientId === "WISP_REDIRECT";
+  const isVisiblePaymentNoticeAndFiscaCode =
+    !isWispRedirecClient ||
+    (isWispRedirecClient && !ignoreRoutesforNoticeNumber.includes(currentPath));
 
   return (
     <>
@@ -124,9 +125,7 @@ export default function DrawerCart(props: Props) {
             <Typography component="div" typography="sidenav" display="block">
               {el.companyName}
             </Typography>
-            {(!isWispRedirecClient ||
-              (isWispRedirecClient &&
-                !ignoreRoutesforNoticeNumber.includes(currentPath))) && (
+            {isVisiblePaymentNoticeAndFiscaCode && (
               <>
                 <Typography
                   component="div"

--- a/src/components/Header/DrawerCart.tsx
+++ b/src/components/Header/DrawerCart.tsx
@@ -39,7 +39,7 @@ export default function DrawerCart(props: Props) {
     (getSessionItem(SessionItems.cartClientId) as string | undefined) ||
     "CHECKOUT";
   const isWispRedirectClient = cartClientId === "WISP_REDIRECT";
-  const isVisiblePaymentNoticeAndFiscaCode =
+  const showPaymentNoticeAndFiscalCode =
     !isWispRedirecClient ||
     (isWispRedirecClient && !ignoreRoutesforNoticeNumber.includes(currentPath));
 

--- a/src/components/Header/DrawerCart.tsx
+++ b/src/components/Header/DrawerCart.tsx
@@ -3,6 +3,8 @@ import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { AccordionDetails, Box, Typography, useTheme } from "@mui/material";
 import { useTranslation } from "react-i18next";
 import React from "react";
+import { CheckoutRoutes } from "routes/models/routeModel";
+import { getSessionItem, SessionItems } from "utils/storage/sessionStorage";
 import { PaymentNotice } from "../../features/payment/models/paymentModel";
 import { moneyFormat } from "../../utils/form/formatters";
 import { truncateText } from "../../utils/transformers/text";
@@ -23,6 +25,19 @@ export default function DrawerCart(props: Props) {
     (panel: string) => (_event: React.SyntheticEvent, newExpanded: boolean) => {
       setExpanded(newExpanded ? panel : false);
     };
+
+  const ignoreRoutesforNoticeNumber: Array<string> = [
+    CheckoutRoutes.INSERISCI_EMAIL,
+    CheckoutRoutes.SCEGLI_METODO,
+  ];
+
+  const currentPath = location.pathname.split("/").slice(-1)[0];
+
+  const cartClientId: string =
+    (getSessionItem(SessionItems.cartClientId) as string | undefined) ||
+    "CHECKOUT";
+
+  const isWispRedirecClient = cartClientId === "WISP_REDIRECT";
 
   return (
     <>
@@ -106,30 +121,44 @@ export default function DrawerCart(props: Props) {
             <Typography component="div" typography="sidenav" display="block">
               {el.companyName}
             </Typography>
-            <Typography
-              component="div"
-              typography="body2"
-              display="block"
-              mt={2}
-              color="action.active"
-            >
-              {t("cartDetail.noticeNumber")}
-            </Typography>
-            <Typography component="div" typography="sidenav" display="block">
-              {el.creditorReferenceId ?? el.noticeNumber}
-            </Typography>
-            <Typography
-              component="div"
-              typography="body2"
-              display="block"
-              mt={2}
-              color="action.active"
-            >
-              {t("cartDetail.fiscalCode")}
-            </Typography>
-            <Typography component="div" typography="sidenav" display="block">
-              {el.fiscalCode}
-            </Typography>
+            {(!!isWispRedirecClient ||
+              (isWispRedirecClient &&
+                !ignoreRoutesforNoticeNumber.includes(currentPath))) && (
+              <>
+                <Typography
+                  component="div"
+                  typography="body2"
+                  display="block"
+                  mt={2}
+                  color="action.active"
+                >
+                  {t("cartDetail.noticeNumber")}
+                </Typography>
+                <Typography
+                  component="div"
+                  typography="sidenav"
+                  display="block"
+                >
+                  {el.creditorReferenceId ?? el.noticeNumber}
+                </Typography>
+                <Typography
+                  component="div"
+                  typography="body2"
+                  display="block"
+                  mt={2}
+                  color="action.active"
+                >
+                  {t("cartDetail.fiscalCode")}
+                </Typography>
+                <Typography
+                  component="div"
+                  typography="sidenav"
+                  display="block"
+                >
+                  {el.fiscalCode}
+                </Typography>
+              </>
+            )}
           </AccordionDetails>
         </Accordion>
       ))}

--- a/src/components/Header/DrawerCart.tsx
+++ b/src/components/Header/DrawerCart.tsx
@@ -40,8 +40,9 @@ export default function DrawerCart(props: Props) {
     "CHECKOUT";
   const isWispRedirectClient = cartClientId === "WISP_REDIRECT";
   const showPaymentNoticeAndFiscalCode =
-    !isWispRedirecClient ||
-    (isWispRedirecClient && !ignoreRoutesforNoticeNumber.includes(currentPath));
+    !isWispRedirectClient ||
+    (isWispRedirectClient &&
+      !ignoreRoutesforNoticeNumber.includes(currentPath));
 
   return (
     <>
@@ -125,7 +126,7 @@ export default function DrawerCart(props: Props) {
             <Typography component="div" typography="sidenav" display="block">
               {el.companyName}
             </Typography>
-            {isVisiblePaymentNoticeAndFiscaCode && (
+            {showPaymentNoticeAndFiscalCode && (
               <>
                 <Typography
                   component="div"

--- a/src/components/Header/DrawerCart.tsx
+++ b/src/components/Header/DrawerCart.tsx
@@ -3,8 +3,11 @@ import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { AccordionDetails, Box, Typography, useTheme } from "@mui/material";
 import { useTranslation } from "react-i18next";
 import React from "react";
-import { CheckoutRoutes } from "routes/models/routeModel";
-import { getSessionItem, SessionItems } from "utils/storage/sessionStorage";
+import {
+  getSessionItem,
+  SessionItems,
+} from "../../utils/storage/sessionStorage";
+import { CheckoutRoutes } from "../../routes/models/routeModel";
 import { PaymentNotice } from "../../features/payment/models/paymentModel";
 import { moneyFormat } from "../../utils/form/formatters";
 import { truncateText } from "../../utils/transformers/text";

--- a/src/components/Header/DrawerCart.tsx
+++ b/src/components/Header/DrawerCart.tsx
@@ -124,7 +124,7 @@ export default function DrawerCart(props: Props) {
             <Typography component="div" typography="sidenav" display="block">
               {el.companyName}
             </Typography>
-            {(!!isWispRedirecClient ||
+            {(!isWispRedirecClient ||
               (isWispRedirecClient &&
                 !ignoreRoutesforNoticeNumber.includes(currentPath))) && (
               <>


### PR DESCRIPTION

#### Motivation and Context

The goal of this PR is to Do not display the "Notice Code" field in the Cart section on the first two pages:

- `/inserisci-email`
- `/scegli-metodo`
-  `/inserisci-carta`

ONLY for WISP_REDIRECT flow.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):
Before:

<img width="1355" alt="Screenshot 2024-10-24 alle 07 38 28" src="https://github.com/user-attachments/assets/db6a1297-de2d-4038-ad1c-833c66ef8b22">

Now:

<img width="1280" alt="Screenshot 2024-10-24 alle 07 37 35" src="https://github.com/user-attachments/assets/07f6c7e0-aa06-470d-8053-4ec5442136d4">



#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
