### PR TITLE
[CHK-3478] Focusable text should not allow clicks

### DIFF
--- a/src/components/TextFormField/ClickableFieldContainer.tsx
+++ b/src/components/TextFormField/ClickableFieldContainer.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable sonarjs/cognitive-complexity */
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 /* eslint-disable functional/immutable-data */
 /* eslint-disable @typescript-eslint/no-empty-function */
@@ -34,21 +35,25 @@ function ClickableFieldContainer(props: {
     ...props.sx,
   };
 
+  const handleClick = () => {
+    if (!props.disabled && props.onClick) {
+      props.onClick();
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === "Enter" && props.onClick) {
+      props.onClick();
+    }
+  };
+
   return (
     <Box
       data-qaid={props.dataTestId}
       data-qalabel={props.dataTestLabel}
       sx={defaultStyle}
-      onClick={() => {
-        if (!props.disabled) {
-          props.onClick && props.onClick();
-        }
-      }}
-      onKeyDown={(e: React.KeyboardEvent<HTMLDivElement>) => {
-        if (e.key === "Enter") {
-          !!props.onClick && props.onClick();
-        }
-      }}
+      onClick={props.clickable ? handleClick : undefined}
+      onKeyDown={props.clickable ? handleKeyDown : undefined}
       {...(props.clickable ? { tabIndex: 0 } : {})}
     >
       <Box


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
props.clickable now determs if whe initialize an onClick and onKeyDown handler, removing the handlers when not needed

<!--- Describe your changes in detail -->

#### Motivation and Context
This is part of the accessibility update

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
