### PR TITLE
[CHK-3806] fix: get user info after logout 

### DIFF
--- a/src/__integration_tests__/paymentflow.integration.test.ts
+++ b/src/__integration_tests__/paymentflow.integration.test.ts
@@ -69,7 +69,7 @@ const PSP_NOT_FOUND_FAIL = "302016723749670076";
  * Increase default test timeout (120000ms)
  * to support entire payment flow
  */
-jest.setTimeout(40000);
+jest.setTimeout(30000);
 jest.retryTimes(3);
 page.setDefaultNavigationTimeout(30000);
 page.setDefaultTimeout(30000);

--- a/src/__integration_tests__/paymentflow.integration.test.ts
+++ b/src/__integration_tests__/paymentflow.integration.test.ts
@@ -433,7 +433,6 @@ describe("Checkout fails to calculate fee", () => {
       expect(errorDescriptionText).toContain(translation.pspUnavailable.body);
 
       await pspNotFoundCtaElem.click();
-      await page.waitForNavigation();
 
       const currentUrl = await page.evaluate(() => location.href);
       expect(currentUrl).toContain("/scegli-metodo");

--- a/src/__integration_tests__/paymentflow.integration.test.ts
+++ b/src/__integration_tests__/paymentflow.integration.test.ts
@@ -69,7 +69,7 @@ const PSP_NOT_FOUND_FAIL = "302016723749670076";
  * Increase default test timeout (120000ms)
  * to support entire payment flow
  */
-jest.setTimeout(30000);
+jest.setTimeout(40000);
 jest.retryTimes(3);
 page.setDefaultNavigationTimeout(30000);
 page.setDefaultTimeout(30000);

--- a/src/components/commons/LoginHeader.tsx
+++ b/src/components/commons/LoginHeader.tsx
@@ -174,14 +174,23 @@ export default function LoginHeader() {
   const doGetUserInfo = () => {
     void retrieveUserInfo({
       onResponse: (userInfo: UserInfoResponse) => {
-        dispatch(
-          setLoggedUser({
-            id: userInfo.userId,
-            name: userInfo.name,
-            surname: userInfo.familyName,
-          })
+        pipe(
+          getSessionItem(SessionItems.authToken),
+          O.fromNullable,
+          O.fold(
+            () => setLoginButtonReady(true),
+            () => {
+              dispatch(
+                setLoggedUser({
+                  id: userInfo.userId,
+                  name: userInfo.name,
+                  surname: userInfo.familyName,
+                })
+              );
+              setLoginButtonReady(true);
+            }
+          )
         );
-        setLoginButtonReady(true);
       },
       onError: () => {
         setLoginButtonReady(true);

--- a/src/components/commons/LoginHeader.tsx
+++ b/src/components/commons/LoginHeader.tsx
@@ -174,29 +174,38 @@ export default function LoginHeader() {
   const doGetUserInfo = () => {
     void retrieveUserInfo({
       onResponse: (userInfo: UserInfoResponse) => {
-        pipe(
-          getSessionItem(SessionItems.authToken),
-          O.fromNullable,
-          O.fold(
-            () => setLoginButtonReady(true),
-            () => {
-              dispatch(
-                setLoggedUser({
-                  id: userInfo.userId,
-                  name: userInfo.name,
-                  surname: userInfo.familyName,
-                })
-              );
-              setLoginButtonReady(true);
-            }
-          )
-        );
+        checkAuthTokenAndContinue(() => {
+          dispatch(
+            setLoggedUser({
+              id: userInfo.userId,
+              name: userInfo.name,
+              surname: userInfo.familyName,
+            })
+          );
+        });
       },
       onError: () => {
-        setLoginButtonReady(true);
-        navigate(`/${CheckoutRoutes.ERRORE}`);
+        checkAuthTokenAndContinue(() => {
+          navigate(`/${CheckoutRoutes.ERRORE}`);
+        });
       },
     });
+  };
+
+  const checkAuthTokenAndContinue = (onCheckSuccess: () => void) => {
+    pipe(
+      getSessionItem(SessionItems.authToken),
+      O.fromNullable,
+      O.fold(
+        // If authToken is not present discard operation
+        () => setLoginButtonReady(true),
+        // If authToken is present do operation
+        () => {
+          onCheckSuccess();
+          setLoginButtonReady(true);
+        }
+      )
+    );
   };
 
   useEffect(() => {

--- a/src/features/payment/components/IframeCardForm/IframeCardForm.tsx
+++ b/src/features/payment/components/IframeCardForm/IframeCardForm.tsx
@@ -166,7 +166,7 @@ export default function IframeCardForm(props: Props) {
 
         const onPaymentComplete = () => {
           clearNavigationEvents();
-          window.location.replace(`/${CheckoutRoutes.ESITO}`);
+          navigate(`/${CheckoutRoutes.ESITO}`, { replace: true });
         };
 
         const onPaymentRedirect = (urlredirect: string) => {
@@ -176,7 +176,7 @@ export default function IframeCardForm(props: Props) {
 
         const onBuildError = () => {
           setLoading(false);
-          window.location.replace(`/${CheckoutRoutes.ERRORE}`);
+          navigate(`/${CheckoutRoutes.ERRORE}`, { replace: true });
         };
 
         const onAllFieldsLoaded = () => {
@@ -303,7 +303,7 @@ export default function IframeCardForm(props: Props) {
           open={errorModalOpen}
           onClose={() => {
             setErrorModalOpen(false);
-            window.location.replace(`/${CheckoutRoutes.ERRORE}`);
+            navigate(`/${CheckoutRoutes.ERRORE}`, { replace: true });
           }}
           titleId="iframeCardFormErrorTitleId"
           errorId="iframeCardFormErrorId"
@@ -315,7 +315,7 @@ export default function IframeCardForm(props: Props) {
           open={pspNotFoundModal}
           onClose={() => {
             setPspNotFoundModalOpen(false);
-            window.location.replace(`/${CheckoutRoutes.SCEGLI_METODO}`);
+            navigate(`/${CheckoutRoutes.SCEGLI_METODO}`, { replace: true });
           }}
           maxWidth="sm"
           hideIcon={true}
@@ -341,7 +341,7 @@ export default function IframeCardForm(props: Props) {
               variant="contained"
               onClick={() => {
                 setPspNotFoundModalOpen(false);
-                window.location.replace(`/${CheckoutRoutes.SCEGLI_METODO}`);
+                navigate(`/${CheckoutRoutes.SCEGLI_METODO}`, { replace: true });
               }}
               id="pspNotFoundCtaId"
             >

--- a/src/features/payment/components/PaymentChoice/PaymentChoice.tsx
+++ b/src/features/payment/components/PaymentChoice/PaymentChoice.tsx
@@ -160,7 +160,7 @@ export function PaymentChoice(props: {
           open={errorModalOpen}
           onClose={() => {
             setErrorModalOpen(false);
-            window.location.replace(`/${CheckoutRoutes.ERRORE}`);
+            navigate(`/${CheckoutRoutes.ERRORE}`, { replace: true });
           }}
           titleId="iframeCardFormErrorTitleId"
           errorId="iframeCardFormErrorId"

--- a/src/routes/CancelledPage.tsx
+++ b/src/routes/CancelledPage.tsx
@@ -1,6 +1,9 @@
 import { Box, Button, Typography } from "@mui/material";
 import React from "react";
 import { useTranslation } from "react-i18next";
+import { useNavigate } from "react-router-dom";
+import * as O from "fp-ts/Option";
+import { pipe } from "fp-ts/lib/function";
 import { resetThreshold } from "../redux/slices/threshold";
 import cancelled from "../assets/images/response-unrecognized.svg";
 import PageContainer from "../components/PageContent/PageContainer";
@@ -17,10 +20,21 @@ import { checkLogout } from "../utils/api/helper";
 import { removeLoggedUser } from "../redux/slices/loggedUser";
 
 export default function CancelledPage() {
+  const navigate = useNavigate();
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
   const cart = getSessionItem(SessionItems.cart) as Cart | undefined;
-  const redirectUrl = cart?.returnUrls.returnCancelUrl || "/";
+
+  const performRedirect = () => {
+    pipe(
+      cart?.returnUrls.returnCancelUrl,
+      O.fromNullable,
+      O.fold(
+        () => navigate("/", { replace: true }),
+        (cartUrl: string) => window.location.replace(cartUrl)
+      )
+    );
+  };
 
   React.useEffect(() => {
     checkLogout(() => {
@@ -57,9 +71,7 @@ export default function CancelledPage() {
           <Button
             type="button"
             variant="outlined"
-            onClick={() => {
-              window.location.replace(redirectUrl);
-            }}
+            onClick={performRedirect}
             style={{
               width: "100%",
               height: "100%",

--- a/src/routes/InputCardPage.tsx
+++ b/src/routes/InputCardPage.tsx
@@ -182,7 +182,7 @@ export default function InputCardPage() {
           open={pspNotFoundModal}
           onClose={() => {
             setPspNotFoundModalOpen(false);
-            window.location.replace(`/${CheckoutRoutes.SCEGLI_METODO}`);
+            navigate(`/${CheckoutRoutes.SCEGLI_METODO}`, { replace: true });
           }}
           maxWidth="sm"
           hideIcon={true}
@@ -208,7 +208,7 @@ export default function InputCardPage() {
               variant="contained"
               onClick={() => {
                 setPspNotFoundModalOpen(false);
-                window.location.replace(`/${CheckoutRoutes.SCEGLI_METODO}`);
+                navigate(`/${CheckoutRoutes.SCEGLI_METODO}`, { replace: true });
               }}
               id="pspNotFoundCtaId"
             >

--- a/src/routes/KOPage.tsx
+++ b/src/routes/KOPage.tsx
@@ -1,6 +1,9 @@
 import { Box, Button, Typography } from "@mui/material";
 import React from "react";
 import { useTranslation } from "react-i18next";
+import * as O from "fp-ts/Option";
+import { useNavigate } from "react-router-dom";
+import { pipe } from "fp-ts/lib/function";
 import { removeLoggedUser } from "../redux/slices/loggedUser";
 import { resetThreshold } from "../redux/slices/threshold";
 import ko from "../assets/images/response-umbrella.svg";
@@ -17,10 +20,21 @@ import {
 import { checkLogout } from "../utils/api/helper";
 
 export default function KOPage() {
+  const navigate = useNavigate();
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
   const cart = getSessionItem(SessionItems.cart) as Cart | undefined;
-  const redirectUrl = cart?.returnUrls.returnErrorUrl || "/";
+
+  const performRedirect = () => {
+    pipe(
+      cart?.returnUrls.returnErrorUrl,
+      O.fromNullable,
+      O.fold(
+        () => navigate("/", { replace: true }),
+        (cartUrl: string) => window.location.replace(cartUrl)
+      )
+    );
+  };
 
   React.useEffect(() => {
     checkLogout(() => {
@@ -68,9 +82,7 @@ export default function KOPage() {
           <Button
             type="button"
             variant="outlined"
-            onClick={() => {
-              window.location.replace(redirectUrl || "/");
-            }}
+            onClick={performRedirect}
             style={{
               width: "100%",
               height: "100%",

--- a/src/routes/PaymentCheckPage.tsx
+++ b/src/routes/PaymentCheckPage.tsx
@@ -199,7 +199,7 @@ export default function PaymentCheckPage() {
 
   const onCancelResponse = () => {
     setCancelLoading(false);
-    navigate(`/${CheckoutRoutes.ANNULLATO}`, { replace: true });
+    navigate(`/${CheckoutRoutes.ANNULLATO}`);
   };
 
   const onCancelPaymentSubmit = () => {
@@ -492,7 +492,7 @@ export default function PaymentCheckPage() {
               variant="contained"
               onClick={() => {
                 setPspNotFoundModalOpen(false);
-                navigate(`/${CheckoutRoutes.SCEGLI_METODO}`);
+                navigate(`/${CheckoutRoutes.SCEGLI_METODO}`, { replace: true });
               }}
               id="pspNotFoundCtaId"
             >

--- a/src/routes/PaymentCheckPage.tsx
+++ b/src/routes/PaymentCheckPage.tsx
@@ -199,7 +199,7 @@ export default function PaymentCheckPage() {
 
   const onCancelResponse = () => {
     setCancelLoading(false);
-    navigate(`/${CheckoutRoutes.ANNULLATO}`);
+    navigate(`/${CheckoutRoutes.ANNULLATO}`, { replace: true });
   };
 
   const onCancelPaymentSubmit = () => {

--- a/src/routes/PaymentCheckPage.tsx
+++ b/src/routes/PaymentCheckPage.tsx
@@ -466,7 +466,7 @@ export default function PaymentCheckPage() {
           open={pspNotFoundModal}
           onClose={() => {
             setPspNotFoundModalOpen(false);
-            window.location.replace(`/${CheckoutRoutes.SCEGLI_METODO}`);
+            navigate(`/${CheckoutRoutes.SCEGLI_METODO}`, { replace: true });
           }}
           maxWidth="sm"
           hideIcon={true}
@@ -492,7 +492,7 @@ export default function PaymentCheckPage() {
               variant="contained"
               onClick={() => {
                 setPspNotFoundModalOpen(false);
-                window.location.replace(`/${CheckoutRoutes.SCEGLI_METODO}`);
+                navigate(`/${CheckoutRoutes.SCEGLI_METODO}`);
               }}
               id="pspNotFoundCtaId"
             >

--- a/src/routes/PaymentResponsePageV2.tsx
+++ b/src/routes/PaymentResponsePageV2.tsx
@@ -1,6 +1,9 @@
 import { Box, Button, Typography } from "@mui/material";
 import { default as React, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { useNavigate } from "react-router-dom";
+import { pipe } from "fp-ts/lib/function";
+import * as O from "fp-ts/Option";
 import { removeLoggedUser } from "../redux/slices/loggedUser";
 import { checkLogout } from "../utils/api/helper";
 import FindOutMoreModal from "../components/modals/FindOutMoreModal";
@@ -36,6 +39,7 @@ type CartInformation = {
 };
 
 export default function PaymentResponsePageV2() {
+  const navigate = useNavigate();
   const outcome = getFragmentParameter(
     window.location.href,
     ROUTE_FRAGMENT.OUTCOME,
@@ -84,6 +88,17 @@ export default function PaymentResponsePageV2() {
   };
 
   const dispatch = useAppDispatch();
+
+  const performRedirect = () => {
+    pipe(
+      cart,
+      O.fromNullable,
+      O.fold(
+        () => navigate(cartInformation.redirectUrl, { replace: true }),
+        () => window.location.replace(cartInformation.redirectUrl)
+      )
+    );
+  };
 
   useEffect(() => {
     checkLogout(() => {
@@ -170,9 +185,7 @@ export default function PaymentResponsePageV2() {
             )}
             <Button
               variant="outlined"
-              onClick={() => {
-                window.location.replace(cartInformation.redirectUrl);
-              }}
+              onClick={performRedirect}
               sx={{
                 width: "100%",
                 minHeight: 45,


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- if `authToken `on `sessionStorage `is not present, discard get user response of LoginHeader (both success and error case)
- change `window.location.replace` with `navigate` in order to prevent app to be refreshed on redirect to internal page

<!--- Describe your changes in detail -->

#### Motivation and Context
The goal of this PR is to fix a racing condition of **get users** with **logout** after a payment error.
On error page a get user is performed despite having previously logged out.

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

On error page logged user must not be present

Before 
![localhost_1234_errore](https://github.com/user-attachments/assets/6757585c-d021-4a03-a10d-b42a722e829c)

After
![localhost_1234_errore (1)](https://github.com/user-attachments/assets/d8a54fb7-4321-4e63-b22b-3417b50553c6)

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
