### PR TITLE
fix: psp page list reload

### DIFF
--- a/src/routes/PaymentPspListPage.tsx
+++ b/src/routes/PaymentPspListPage.tsx
@@ -69,10 +69,10 @@ export default function PaymentPspListPage() {
       calculateFeeResponse,
       CalculateFeeResponse.decode,
       O.fromEither,
-      O.chain((resp) => 
+      O.chain((resp) =>
         pipe(
           O.fromNullable(resp.belowThreshold),
-          O.map(belowThreshold => {
+          O.map((belowThreshold) => {
             dispatch(setThreshold({ belowThreshold }));
             return resp.bundles.slice();
           })

--- a/src/routes/PaymentPspListPage.tsx
+++ b/src/routes/PaymentPspListPage.tsx
@@ -15,6 +15,8 @@ import ErrorModal from "../components/modals/ErrorModal";
 import CheckoutLoader from "../components/PageContent/CheckoutLoader";
 import PageContainer from "../components/PageContent/PageContainer";
 import { PaymentMethod } from "../features/payment/models/paymentModel";
+import { useAppDispatch } from "../redux/hooks/hooks";
+import { setThreshold } from "../redux/slices/threshold";
 import {
   getReCaptchaKey,
   getSessionItem,
@@ -31,6 +33,7 @@ import { CheckoutRoutes } from "./models/routeModel";
 export default function PaymentPspListPage() {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const dispatch = useAppDispatch();
 
   const ref = React.useRef<ReCAPTCHA>(null);
   const [errorModalOpen, setErrorModalOpen] = React.useState(false);
@@ -66,7 +69,13 @@ export default function PaymentPspListPage() {
       calculateFeeResponse,
       CalculateFeeResponse.decode,
       O.fromEither,
-      O.map((resp) => resp.bundles.slice()),
+      O.map((resp) => {
+        // Handle the threshold here
+        if (resp.belowThreshold !== undefined) {
+          dispatch(setThreshold({ belowThreshold: resp.belowThreshold }));
+        }
+        return resp.bundles.slice();
+      }),
       O.filter((bundles) => bundles.length > 0),
       O.fold(
         () => onError(ErrorsType.GENERIC_ERROR),

--- a/src/routes/PaymentPspListPage.tsx
+++ b/src/routes/PaymentPspListPage.tsx
@@ -69,13 +69,15 @@ export default function PaymentPspListPage() {
       calculateFeeResponse,
       CalculateFeeResponse.decode,
       O.fromEither,
-      O.map((resp) => {
-        // Handle the threshold here
-        if (resp.belowThreshold !== undefined) {
-          dispatch(setThreshold({ belowThreshold: resp.belowThreshold }));
-        }
-        return resp.bundles.slice();
-      }),
+      O.chain((resp) => 
+        pipe(
+          O.fromNullable(resp.belowThreshold),
+          O.map(belowThreshold => {
+            dispatch(setThreshold({ belowThreshold }));
+            return resp.bundles.slice();
+          })
+        )
+      ),
       O.filter((bundles) => bundles.length > 0),
       O.fold(
         () => onError(ErrorsType.GENERIC_ERROR),


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

Add the necessary logic to the PSP list page to set the threshold value in the Redux state when the page reloads.

#### List of Changes
Set the Redux state for the threshold information when the page reloads. If the information is unavailable, display an error dialog.

<!--- Describe your changes in detail -->

#### Motivation and Context
Reloading the PSP list page caused a flow issue: clicking 'Continue' redirected the user back to the payment method details section. This happened because the threshold information was removed from the Redux state after the page reload.

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

localhost

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
