### PR TITLE
fix: [PIDM-708] removed unwanted padding on banner

### DIFF
--- a/src/routes/PaymentResponsePage.tsx
+++ b/src/routes/PaymentResponsePage.tsx
@@ -264,7 +264,7 @@ export default function PaymentResponsePage() {
               </Button>
             </Box>
             {conf.CHECKOUT_SURVEY_SHOW && outcome === ViewOutcomeEnum.SUCCESS && (
-              <Box sx={{ width: "100%" }} px={{ xs: 8, sm: 0 }}>
+              <Box sx={{ width: "100%" }} px={{ xs: 0, sm: 0 }}>
                 <SurveyLink />
               </Box>
             )}


### PR DESCRIPTION
#### List of Changes

Padding on extra small devices has been removed due to not being the desired final product.

#### Motivation and Context

#### How Has This Been Tested?

Manual testing in local environment.

#### Screenshots (if appropriate):

<img width="400" height="619" alt="image" src="https://github.com/user-attachments/assets/2d141302-3a19-4480-a9e3-b2b626647591" />

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
