### PR TITLE
feat: [CHK-4860] handle retry after header

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,21 +142,28 @@ The app uses i18n for translations, in order to add a new one follow this steps:
    }
    ```
    
-   ## Polling
+## Polling
 
-   The function exponentialPollingWithPromisePredicateFetch uses the variableBackoff formula to calculate the polling intervals based on the attempt number:
+The function `exponentialPollingWithPromisePredicateFetch` computes the interval between retries using `variableBackoff`.
 
-   -  For attempts less than or equal to RETRY_NUMBERS_LINEAR, it returns a fixed delay.
+- For the first `CHECKOUT_API_RETRY_NUMBERS_LINEAR` retry attempts, it uses a fixed `delay` (`CHECKOUT_API_RETRY_DELAY`).
+- After that, the delay increases linearly (`delay * 2`, `delay * 3`, ...).
+- If a `429` response includes a `Retry-After` header, that value overrides the next retry delay.
 
-   -  For attempts greater than that, the delay increases linearly according to the formula.
+```ts
+const variableBackoff = (attempt: number): Millisecond => {
+   if (retryAfterOverrideMs !== undefined) {
+      const computedDelay = Math.max(0, retryAfterOverrideMs);
+      retryAfterOverrideMs = undefined;
+      return computedDelay as Millisecond;
+   }
 
-   - 
-   ```sh
-   const variableBackoff = (attempt: number): Millisecond => {
-      if (attempt <= RETRY_NUMBERS_LINEAR) {
-         return delay as Millisecond;
-      }
+   const totalAttempts = attempt + 1;
+   if (totalAttempts <= RETRY_NUMBERS_LINEAR) {
+      return delay as Millisecond;
+   }
 
-      return (delay * (attempt - RETRY_NUMBERS_LINEAR)) as Millisecond;
-   };
-   ```
+   const multiplier = totalAttempts - RETRY_NUMBERS_LINEAR + 1;
+   return (delay * multiplier) as Millisecond;
+};
+```

--- a/src/utils/__tests__/api/response.test.ts
+++ b/src/utils/__tests__/api/response.test.ts
@@ -10,6 +10,9 @@ jest.mock("../../config/config", () => ({
     CHECKOUT_ENV: "test",
     CHECKOUT_PAGOPA_APIM_HOST: "https://mock-host",
     CHECKOUT_API_ECOMMERCE_BASEPATH: "/v1",
+    CHECKOUT_API_RETRY_DELAY: 200,
+    CHECKOUT_API_RETRY_NUMBERS: 3,
+    CHECKOUT_API_TIMEOUT: 1000,
   })),
 }));
 
@@ -97,6 +100,8 @@ describe("callServices", () => {
 });
 
 describe("response.ts polling predicate", () => {
+  type PredicateResult = boolean | { retry: boolean; retryAfterMs?: number };
+
   const mkRes = (status: number, isFinal: boolean) =>
     ({
       status,
@@ -104,6 +109,14 @@ describe("response.ts polling predicate", () => {
         return this;
       },
       json: async () => ({ isFinalStatus: isFinal }),
+    } as unknown as Response);
+
+  const mk429Res = (retryAfterHeader: string | null) =>
+    ({
+      status: 429,
+      headers: {
+        get: () => retryAfterHeader,
+      },
     } as unknown as Response);
 
   const getFreshPredicate = async () => {
@@ -115,7 +128,7 @@ describe("response.ts polling predicate", () => {
     } = require("../../config/fetch");
     return exponentialPollingWithPromisePredicateFetch.mock.calls[0][4] as (
       r: Response
-    ) => Promise<boolean>;
+    ) => Promise<PredicateResult>;
   };
 
   it("should return false immediately when status===200 and isFinalStatus is true", async () => {
@@ -145,5 +158,42 @@ describe("response.ts polling predicate", () => {
     await expect(predicate(mkRes(500, false))).resolves.toBe(true);
     await expect(predicate(mkRes(502, false))).resolves.toBe(true);
     await expect(predicate(mkRes(503, false))).resolves.toBe(true);
+  });
+
+  it("should parse Retry-After seconds on 429", async () => {
+    const predicate = await getFreshPredicate();
+    await expect(predicate(mk429Res("2"))).resolves.toEqual({
+      retry: true,
+      retryAfterMs: 2000,
+    });
+  });
+
+  it("should parse Retry-After date on 429", async () => {
+    const predicate = await getFreshPredicate();
+    const nowSpy = jest.spyOn(Date, "now").mockReturnValue(1000);
+    const retryAfterDate = "Thu, 01 Jan 1970 00:00:04 GMT";
+
+    await expect(predicate(mk429Res(retryAfterDate))).resolves.toEqual({
+      retry: true,
+      retryAfterMs: 3000,
+    });
+
+    nowSpy.mockRestore();
+  });
+
+  it("should fallback to configured delay when Retry-After is invalid", async () => {
+    const predicate = await getFreshPredicate();
+    await expect(predicate(mk429Res("not-a-valid-value"))).resolves.toEqual({
+      retry: true,
+      retryAfterMs: 200,
+    });
+  });
+
+  it("should fallback to configured delay when Retry-After is missing", async () => {
+    const predicate = await getFreshPredicate();
+    await expect(predicate(mk429Res(null))).resolves.toEqual({
+      retry: true,
+      retryAfterMs: 200,
+    });
   });
 });

--- a/src/utils/__tests__/api/response.test.ts
+++ b/src/utils/__tests__/api/response.test.ts
@@ -1,7 +1,8 @@
 jest.mock("../../config/fetch", () => ({
   retryingFetch: jest.fn(() => jest.fn()),
   constantPollingWithPromisePredicateFetch: jest.fn(() => jest.fn()),
-  exponetialPollingWithPromisePredicateFetch: jest.fn((_) => jest.fn()),
+  exponentialPollingWithPromisePredicateFetch: jest.fn((_) => jest.fn()),
+  RetryDecision: {},
 }));
 
 jest.mock("../../config/config", () => ({
@@ -109,10 +110,10 @@ describe("response.ts polling predicate", () => {
     jest.resetModules();
     await import("../../api/response");
     const {
-      exponetialPollingWithPromisePredicateFetch,
+      exponentialPollingWithPromisePredicateFetch,
       /* eslint-disable-next-line @typescript-eslint/no-var-requires */
     } = require("../../config/fetch");
-    return exponetialPollingWithPromisePredicateFetch.mock.calls[0][4] as (
+    return exponentialPollingWithPromisePredicateFetch.mock.calls[0][4] as (
       r: Response
     ) => Promise<boolean>;
   };

--- a/src/utils/__tests__/api/response.test.ts
+++ b/src/utils/__tests__/api/response.test.ts
@@ -11,7 +11,7 @@ jest.mock("../../config/config", () => ({
     CHECKOUT_PAGOPA_APIM_HOST: "https://mock-host",
     CHECKOUT_API_ECOMMERCE_BASEPATH: "/v1",
     CHECKOUT_API_RETRY_DELAY: 200,
-    CHECKOUT_API_RETRY_NUMBERS: 3,
+    CHECKOUT_API_RETRY_NUMBERS: 4,
     CHECKOUT_API_TIMEOUT: 1000,
   })),
 }));

--- a/src/utils/__tests__/config/fetch.test.ts
+++ b/src/utils/__tests__/config/fetch.test.ts
@@ -48,7 +48,7 @@ const generateExpectedDelays = (
 import { Millisecond } from "@pagopa/ts-commons/lib/units";
 import {
   constantPollingWithPromisePredicateFetch,
-  exponetialPollingWithPromisePredicateFetch,
+  exponentialPollingWithPromisePredicateFetch,
   retryingFetch,
 } from "../../config/fetch";
 
@@ -173,7 +173,7 @@ describe("retryingFetch", () => {
 
     const shouldAbort = Promise.resolve(false);
 
-    const fetchWithRetry = exponetialPollingWithPromisePredicateFetch(
+    const fetchWithRetry = exponentialPollingWithPromisePredicateFetch(
       shouldAbort,
       2, // max retries
       100, // initial delay (will backoff after 1st retry)
@@ -189,7 +189,7 @@ describe("retryingFetch", () => {
   });
 });
 
-describe("exponetialPollingWithPromisePredicateFetch backoff behavior", () => {
+describe("exponentialPollingWithPromisePredicateFetch backoff behavior", () => {
   beforeAll(() => {
     jest.useFakeTimers(); // legacy timers
   });
@@ -225,7 +225,7 @@ describe("exponetialPollingWithPromisePredicateFetch backoff behavior", () => {
 
     (global as any).fetch = fetchMock;
 
-    const fetchWithRetry = exponetialPollingWithPromisePredicateFetch(
+    const fetchWithRetry = exponentialPollingWithPromisePredicateFetch(
       shouldAbort,
       3,
       10,
@@ -247,5 +247,52 @@ describe("exponetialPollingWithPromisePredicateFetch backoff behavior", () => {
 
     expect(response.status).toBe(200);
     expect(fetchMock).toHaveBeenCalledTimes(expectedDelays.length);
+  });
+
+  it("should honor retryAfterMs override without adding extra backoff", async () => {
+    const condition = jest
+      .fn()
+      .mockResolvedValueOnce({ retry: true, retryAfterMs: 50 })
+      .mockResolvedValueOnce(false);
+
+    const shouldAbort = Promise.resolve(false);
+
+    const callTimes: Array<number> = [];
+    const fetchMock = jest
+      .fn()
+      .mockImplementationOnce(() => {
+        callTimes.push(Date.now());
+        return Promise.resolve(mockResponse503);
+      })
+      .mockImplementationOnce(() => {
+        callTimes.push(Date.now());
+        return Promise.resolve(mockResponse200);
+      });
+
+    (global as any).fetch = fetchMock;
+
+    const fetchWithRetry = exponentialPollingWithPromisePredicateFetch(
+      shouldAbort,
+      2,
+      10,
+      1000 as Millisecond,
+      condition
+    );
+
+    const promise = fetchWithRetry("https://api.example.com");
+
+    await jest.advanceTimersByTimeAsync(0);
+    expect(callTimes.length).toBe(1);
+
+    await jest.advanceTimersByTimeAsync(49);
+    expect(callTimes.length).toBe(1);
+
+    await jest.advanceTimersByTimeAsync(1);
+    expect(callTimes.length).toBe(2);
+
+    const response = await promise;
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/utils/api/response.ts
+++ b/src/utils/api/response.ts
@@ -8,6 +8,7 @@ import * as T from "fp-ts/Task";
 import { pipe } from "fp-ts/function";
 import { DeferredPromise } from "@pagopa/ts-commons/lib/promises";
 import { Millisecond } from "@pagopa/ts-commons/lib/units";
+import { createCounter } from "../../utils/counter";
 import { ecommerceTransactionOutcome } from "../transactions/transactionHelper";
 import {
   exponentialPollingWithPromisePredicateFetch,
@@ -41,6 +42,8 @@ export const decodeToUUID = (base64: string) => {
   return hexToUuid(bytes.toString("hex")).replace(/-/g, "");
 };
 
+const counter = createCounter();
+
 const parseRetryAfterToMs = (
   headerValue: string | null,
   fallbackMs: number
@@ -72,6 +75,13 @@ const ecommerceClientWithPollingV1: EcommerceClientV1 = createClientV1({
     delay,
     timeout,
     async (r: Response): Promise<boolean | RetryDecision> => {
+      counter.increment();
+
+      if (counter.getValue() === retries) {
+        counter.reset();
+        return false;
+      }
+
       if (r.status === 429) {
         const retryAfterHeader = r.headers.get("Retry-After");
         return {
@@ -91,6 +101,7 @@ const ecommerceClientWithPollingV1: EcommerceClientV1 = createClientV1({
         return !isFinalStatus;
       }
 
+      counter.reset();
       return false;
     }
   ),

--- a/src/utils/api/response.ts
+++ b/src/utils/api/response.ts
@@ -8,9 +8,11 @@ import * as T from "fp-ts/Task";
 import { pipe } from "fp-ts/function";
 import { DeferredPromise } from "@pagopa/ts-commons/lib/promises";
 import { Millisecond } from "@pagopa/ts-commons/lib/units";
-import { createCounter } from "../../utils/counter";
 import { ecommerceTransactionOutcome } from "../transactions/transactionHelper";
-import { exponetialPollingWithPromisePredicateFetch } from "../config/fetch";
+import {
+  exponentialPollingWithPromisePredicateFetch,
+  RetryDecision,
+} from "../config/fetch";
 import { getUrlParameter } from "../regex/urlUtilities";
 import { getConfigOrThrow } from "../config/config";
 import { getSessionItem, SessionItems } from "../storage/sessionStorage";
@@ -39,21 +41,43 @@ export const decodeToUUID = (base64: string) => {
   return hexToUuid(bytes.toString("hex")).replace(/-/g, "");
 };
 
-const counter = createCounter();
+const parseRetryAfterToMs = (
+  headerValue: string | null,
+  fallbackMs: number
+): number => {
+  if (!headerValue) {
+    return fallbackMs;
+  }
+
+  // Retry-After header in seconds
+  const seconds = Number(headerValue);
+  if (!Number.isNaN(seconds) && seconds >= 0) {
+    return Math.round(seconds * 1000);
+  }
+
+  // Retry-After header as date
+  const dateMs = Date.parse(headerValue);
+  if (!Number.isNaN(dateMs)) {
+    return Math.max(0, dateMs - Date.now());
+  }
+
+  return fallbackMs;
+};
 
 const ecommerceClientWithPollingV1: EcommerceClientV1 = createClientV1({
   baseUrl: config.CHECKOUT_PAGOPA_APIM_HOST,
-  fetchApi: exponetialPollingWithPromisePredicateFetch(
+  fetchApi: exponentialPollingWithPromisePredicateFetch(
     DeferredPromise<boolean>().e1,
     retries,
     delay,
     timeout,
-    async (r: Response): Promise<boolean> => {
-      counter.increment();
-
-      if (counter.getValue() === retries) {
-        counter.reset();
-        return false;
+    async (r: Response): Promise<boolean | RetryDecision> => {
+      if (r.status === 429) {
+        const retryAfterHeader = r.headers.get("Retry-After");
+        return {
+          retry: true,
+          retryAfterMs: parseRetryAfterToMs(retryAfterHeader, delay),
+        };
       }
 
       if (r.status === 404 || (r.status >= 500 && r.status < 600)) {
@@ -67,7 +91,6 @@ const ecommerceClientWithPollingV1: EcommerceClientV1 = createClientV1({
         return !isFinalStatus;
       }
 
-      counter.reset();
       return false;
     }
   ),

--- a/src/utils/config/fetch.ts
+++ b/src/utils/config/fetch.ts
@@ -27,6 +27,17 @@ const API_TIMEOUT = getConfigOrThrow().CHECKOUT_API_TIMEOUT as Millisecond;
 const RETRY_NUMBERS_LINEAR = getConfigOrThrow()
   .CHECKOUT_API_RETRY_NUMBERS_LINEAR as number;
 
+export type RetryDecision = {
+  retry: boolean;
+  retryAfterMs?: number;
+};
+
+type RetryConditionResult = boolean | RetryDecision;
+
+const normalizeRetryConditionResult = (
+  value: RetryConditionResult
+): RetryDecision => (typeof value === "boolean" ? { retry: value } : value);
+
 export function retryingFetch(
   fetchApi: typeof fetch,
   timeout: Millisecond = API_TIMEOUT,
@@ -79,11 +90,12 @@ function retryLogicForTransientResponseError(
 // Handle error that occurs once or at unpredictable intervals.
 //
 function retryLogicOnPromisePredicate(
-  p: (r: Response) => Promise<boolean>,
+  p: (r: Response) => Promise<RetryConditionResult>,
   retryLogic: (
     t: RetriableTask<Error, Response>,
     shouldAbort?: Promise<boolean>
-  ) => TE.TaskEither<Error | "max-retries" | "retry-aborted", Response>
+  ) => TE.TaskEither<Error | "max-retries" | "retry-aborted", Response>,
+  onRetryDecision?: (decision: RetryDecision) => void
 ): typeof retryLogic {
   return (t: RetriableTask<Error, Response>, shouldAbort?: Promise<boolean>) =>
     retryLogic(
@@ -95,8 +107,17 @@ function retryLogicOnPromisePredicate(
               () => p(r),
               () => TransientError
             ),
-            TE.chain<Error | TransientError, boolean, Response>((d) =>
-              TE.fromEither(d ? E.left(TransientError) : E.right(r))
+            TE.map(normalizeRetryConditionResult),
+            TE.chain<Error | TransientError, RetryDecision, Response>(
+              (decision) => {
+                if (decision.retry) {
+                  onRetryDecision?.(decision);
+                }
+
+                return TE.fromEither(
+                  decision.retry ? E.left(TransientError) : E.right(r)
+                );
+              }
             )
           )
         )
@@ -114,7 +135,7 @@ export const constantPollingWithPromisePredicateFetch = (
   retries: number,
   delay: number,
   timeout: Millisecond = API_TIMEOUT,
-  condition: (r: Response) => Promise<boolean>
+  condition: (r: Response) => Promise<RetryConditionResult>
 ) => {
   // fetch client that can be aborted for timeout
   const abortableFetch = AbortableFetch((global as any).fetch);
@@ -136,12 +157,12 @@ export const constantPollingWithPromisePredicateFetch = (
   )(timeoutFetch as any);
 };
 
-export const exponetialPollingWithPromisePredicateFetch = (
+export const exponentialPollingWithPromisePredicateFetch = (
   shouldAbort: Promise<boolean>,
   retries: number,
   delay: number,
   timeout: Millisecond = API_TIMEOUT,
-  condition: (r: Response) => Promise<boolean>
+  condition: (r: Response) => Promise<RetryConditionResult>
 ) => {
   // fetch client that can be aborted for timeout
   const abortableFetch = AbortableFetch((global as any).fetch);
@@ -149,7 +170,14 @@ export const exponetialPollingWithPromisePredicateFetch = (
 
   // use a exponetial backoff
   /* eslint-disable functional/no-let */
+  let retryAfterOverrideMs: number | undefined;
   const variableBackoff = (attempt: number): Millisecond => {
+    if (retryAfterOverrideMs !== undefined) {
+      const computedDelay = Math.max(0, retryAfterOverrideMs);
+      retryAfterOverrideMs = undefined;
+      return computedDelay as Millisecond;
+    }
+
     const totalAttempts = attempt + 1;
     if (totalAttempts <= RETRY_NUMBERS_LINEAR) {
       return delay as Millisecond;
@@ -163,7 +191,12 @@ export const exponetialPollingWithPromisePredicateFetch = (
   // use to define transient errors
   const retryWithPromisePredicate = retryLogicOnPromisePredicate(
     condition,
-    retryLogic
+    retryLogic,
+    (decision) => {
+      if (decision.retryAfterMs !== undefined) {
+        retryAfterOverrideMs = decision.retryAfterMs;
+      }
+    }
   );
 
   return retriableFetch(


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- Refactored outcome polling logic to handle Retry-After headers
- Added new unit test for retry-after case
- Updated polling section on readme

#### Motivation and Context

The goal is to handle a possible a `429 Too Many Requests` response with a `Retry-After` header from the `GET /outcomes` API, sending the next request once the required time has elapsed
#### How Has This Been Tested?

- Unit tests
- Local & DEV tests

#### Screenshots (if appropriate):

429 response:
<img width="1060" height="411" alt="image" src="https://github.com/user-attachments/assets/fa042409-49ee-4741-bdd2-eb830c8f88db" />

Following request after the time specified in the Retry-After has elapsed:
<img width="1060" height="411" alt="image" src="https://github.com/user-attachments/assets/bc409760-7455-4f8b-8d86-f0bc3c9cb51a" />


#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
