### PR TITLE
[PID-2121] fix: reset polling counter when transaction reaches final status

### DIFF
--- a/src/utils/api/response.ts
+++ b/src/utils/api/response.ts
@@ -98,9 +98,9 @@ const ecommerceClientWithPollingV1: EcommerceClientV1 = createClientV1({
         const { isFinalStatus } = (await r
           .clone()
           .json()) as TransactionOutcomeInfo;
-          if (isFinalStatus) {
-            counter.reset();
-          }
+        if (isFinalStatus) {
+          counter.reset();
+        }
         return !isFinalStatus;
       }
 

--- a/src/utils/api/response.ts
+++ b/src/utils/api/response.ts
@@ -98,6 +98,9 @@ const ecommerceClientWithPollingV1: EcommerceClientV1 = createClientV1({
         const { isFinalStatus } = (await r
           .clone()
           .json()) as TransactionOutcomeInfo;
+          if (isFinalStatus) {
+            counter.reset();
+          }
         return !isFinalStatus;
       }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- Added `counter.reset()` call in the polling fetch predicate when a transaction 
  reaches a final status (`isFinalStatus === true`)

#### Motivation and Context

The polling counter used in `ecommerceClientWithPolling` was not being reset 
when a transaction reached a final status. This caused subsequent payment attempts 
within the same session to start with a reduced number of retries available, 
potentially causing premature polling termination on the second (or later) payment.

The counter was only being reset in two cases:
1. When all retries were exhausted
2. When an unhandled HTTP status was received

It was never reset on a successful final status response, leading to the bug.

#### How Has This Been Tested?

Manually tested by performing two consecutive payment flows in the same session 

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
