### PR TITLE
feat: [PIDM-2152] add supply only npg sdk sync pipeline

### DIFF
--- a/.devops/azure-templates/sync-npg-sdk-steps.yml
+++ b/.devops/azure-templates/sync-npg-sdk-steps.yml
@@ -1,0 +1,145 @@
+parameters:
+  - name: npg_origin
+    type: string
+  - name: integrity_endpoint
+    type: string
+  - name: storage_account
+    type: string
+  - name: cdn_rg
+    type: string
+  - name: cdn_profile
+    type: string
+  - name: cdn_endpoint
+    type: string
+  - name: service_connection
+    type: string
+  - name: app_insights_name
+    type: string
+  - name: app_insights_rg
+    type: string
+
+steps:
+  - checkout: none
+
+  - task: AzureCLI@2
+    displayName: 'Download, hash, and upload NPG SDK'
+    inputs:
+      azureSubscription: '${{ parameters.service_connection }}'
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -euo pipefail
+
+        SDK_URL="${{ parameters.npg_origin }}/monetaweb/resources/hfsdk.js"
+        echo "Downloading SDK from ${SDK_URL}"
+
+        HTTP_CODE=$(curl -sSL -w "%{http_code}" -o /tmp/hfsdk.js "${SDK_URL}")
+        if [ "${HTTP_CODE}" != "200" ]; then
+          echo "##vso[task.logissue type=error]SDK download failed with HTTP ${HTTP_CODE}"
+          exit 1
+        fi
+
+        FILE_SIZE=$(stat -c%s /tmp/hfsdk.js)
+        echo "SDK downloaded: ${FILE_SIZE} bytes"
+
+        HASH=$(openssl dgst -sha384 -binary /tmp/hfsdk.js | openssl base64 -A)
+        INTEGRITY="sha384-${HASH}"
+        echo "Computed integrity: ${INTEGRITY}"
+
+        # Origin validation: compare the computed hash against NPG's own published hash,
+        # fetched from the payment-methods-handler integrity endpoint (exposed on APIM in
+        # the ecommerce-for-checkout group). The pipeline holds no NPG credential; the
+        # handler owns the npg-api-key and proxies NPG /build/integrity.
+        echo "Fetching source-of-truth integrity from ${{ parameters.integrity_endpoint }}"
+        SOT_CODE=$(curl -sSL -w "%{http_code}" -o /tmp/sot.json "${{ parameters.integrity_endpoint }}")
+        if [ "${SOT_CODE}" != "200" ]; then
+          echo "##vso[task.logissue type=error]Integrity endpoint call failed with HTTP ${SOT_CODE}"
+          exit 1
+        fi
+
+        SOT_INTEGRITY=$(jq -r '.integrityHash // .integrity // empty' /tmp/sot.json)
+        if [ -z "${SOT_INTEGRITY}" ]; then
+          echo "##vso[task.logissue type=error]Integrity endpoint returned no hash"
+          exit 1
+        fi
+        echo "Source-of-truth integrity: ${SOT_INTEGRITY}"
+
+        # Normalize the optional sha384- prefix on both sides before comparing.
+        if [ "${INTEGRITY#sha384-}" != "${SOT_INTEGRITY#sha384-}" ]; then
+          echo "##vso[task.logissue type=error]Integrity mismatch: computed ${INTEGRITY} vs source-of-truth ${SOT_INTEGRITY}. Not publishing; keeping last-known-good."
+          exit 1
+        fi
+        echo "Integrity verified against NPG source of truth"
+
+        echo "{\"integrityHash\":\"${INTEGRITY}\"}" > /tmp/hfsdk.integrity.json
+
+        echo "Uploading SDK to checkout CDN storage (npg/sdk/hfsdk.js)"
+        az storage blob upload \
+          --account-name "${{ parameters.storage_account }}" \
+          --container-name '$web' \
+          --name "npg/sdk/hfsdk.js" \
+          --file /tmp/hfsdk.js \
+          --content-type "application/javascript" \
+          --overwrite
+
+        echo "Uploading integrity JSON to checkout CDN storage (npg/sdk/hfsdk.integrity.json)"
+        az storage blob upload \
+          --account-name "${{ parameters.storage_account }}" \
+          --container-name '$web' \
+          --name "npg/sdk/hfsdk.integrity.json" \
+          --file /tmp/hfsdk.integrity.json \
+          --content-type "application/json" \
+          --overwrite
+
+        echo "Purging CDN for /npg/sdk/*"
+        # keep working after the built-in cdn/afd commands are removed from az core.
+        az config set extension.use_dynamic_install=yes_without_prompt --only-show-errors
+        az afd endpoint purge \
+          -g "${{ parameters.cdn_rg }}" \
+          --endpoint-name "${{ parameters.cdn_endpoint }}" \
+          --profile-name "${{ parameters.cdn_profile }}" \
+          --content-paths "/npg/sdk/*"
+
+        # Success heartbeat: emit a NpgSdkSyncSuccess customEvent to App Insights.
+        # No heartbeat in the last 3h => the sync has stopped or is failing
+        echo "Emitting sync-success heartbeat to App Insights"
+        # disable xtrace so the App Insights connection string / instrumentation
+        # key are never echoed to the log
+        set +x
+        # bounded with timeout so a hung ARM call can never stall the pipeline
+        AI_CONN=$(timeout 30 az monitor app-insights component show \
+          --app "${{ parameters.app_insights_name }}" \
+          -g "${{ parameters.app_insights_rg }}" \
+          --query connectionString -o tsv 2>/dev/null || true)
+        if [ -n "${AI_CONN}" ]; then
+          IKEY=$(printf '%s' "${AI_CONN}" | sed -n 's/.*InstrumentationKey=\([^;]*\).*/\1/p')
+          INGEST=$(printf '%s' "${AI_CONN}" | sed -n 's/.*IngestionEndpoint=\([^;]*\).*/\1/p')
+          HEARTBEAT_TIME=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
+          # payload + response go to unpredictable temp files (mktemp). Keeping the
+          # iKey in the payload file means it never lands in the process args (argv).
+          HB_PAYLOAD=$(mktemp)
+          HB_RESP=$(mktemp)
+          printf '{"name":"Microsoft.ApplicationInsights.Event","time":"%s","iKey":"%s","data":{"baseType":"EventData","baseData":{"ver":2,"name":"NpgSdkSyncSuccess","properties":{"integrity":"%s"}}}}' \
+            "${HEARTBEAT_TIME}" "${IKEY}" "${INTEGRITY}" > "${HB_PAYLOAD}"
+          # -o sends the body to a file (never stdout); -w prints only the HTTP
+          # status; connect/max timeouts guarantee the call cannot hang the job.
+          HB_CODE=$(curl -sS -o "${HB_RESP}" -w '%{http_code}' \
+            --connect-timeout 10 --max-time 30 \
+            -X POST "${INGEST}v2/track" -H 'Content-Type: application/json' \
+            -d @"${HB_PAYLOAD}" || true)
+          # itemsAccepted is the authoritative "did it land" signal - a 200 alone is
+          # not enough (App Insights can 200 with itemsAccepted:0). The v2/track
+          # response never contains the iKey, so these fields are safe to log.
+          HB_ACCEPTED=$(sed -n 's/.*"itemsAccepted":\([0-9][0-9]*\).*/\1/p' "${HB_RESP}")
+          HB_ERRORS=$(sed -n 's/.*\("errors":\[[^]]*\]\).*/\1/p' "${HB_RESP}")
+          rm -f "${HB_PAYLOAD}" "${HB_RESP}"
+          if [ "${HB_ACCEPTED:-0}" -ge 1 ]; then
+            echo "Heartbeat emitted (HTTP ${HB_CODE:-000}, itemsAccepted=${HB_ACCEPTED})"
+          else
+            echo "##vso[task.logissue type=warning]Heartbeat NOT accepted by App Insights (HTTP ${HB_CODE:-000}, itemsAccepted=${HB_ACCEPTED:-0}) ${HB_ERRORS}; sync itself succeeded."
+          fi
+        else
+          echo "##vso[task.logissue type=warning]Could not resolve App Insights connection string; heartbeat skipped (sync itself succeeded)"
+        fi
+
+        echo "Sync complete"

--- a/.devops/pagopa-deploy-pipelines.yml
+++ b/.devops/pagopa-deploy-pipelines.yml
@@ -145,7 +145,7 @@ stages:
               azureSubscription: 'DEV-PAGOPA-SERVICE-CONN'
               scriptLocation: inlineScript
               inlineScript: |
-                call az storage blob sync --container $web --account-name ${{ variables.DEV_STORAGE_ACCOUNT }} -s "$(Pipeline.Workspace)\Bundle_DEV"
+                call az storage blob sync --container $web --account-name ${{ variables.DEV_STORAGE_ACCOUNT }} -s "$(Pipeline.Workspace)\Bundle_DEV" --exclude-path npg/sdk
 
           - task: AzureCLI@1
             displayName: 'Purge CDN endpoint on DEV'
@@ -297,7 +297,7 @@ stages:
               azureSubscription: 'UAT-PAGOPA-SERVICE-CONN'
               scriptLocation: inlineScript
               inlineScript: |
-                call az storage blob sync --container $web --account-name ${{ variables.UAT_STORAGE_ACCOUNT }} -s "$(Pipeline.Workspace)\Bundle_UAT"
+                call az storage blob sync --container $web --account-name ${{ variables.UAT_STORAGE_ACCOUNT }} -s "$(Pipeline.Workspace)\Bundle_UAT" --exclude-path npg/sdk
 
           - task: AzureCLI@1
             displayName: 'Purge CDN endpoint on UAT'
@@ -402,7 +402,7 @@ stages:
               azureSubscription: 'PROD-PAGOPA-SERVICE-CONN'
               scriptLocation: inlineScript
               inlineScript: |
-                call az storage blob sync --container $web --account-name ${{ variables.PROD_STORAGE_ACCOUNT }} -s "$(Pipeline.Workspace)\Bundle"
+                call az storage blob sync --container $web --account-name ${{ variables.PROD_STORAGE_ACCOUNT }} -s "$(Pipeline.Workspace)\Bundle" --exclude-path npg/sdk
 
           - task: AzureCLI@1
             displayName: 'Purge CDN endpoint on PROD'

--- a/.devops/pagopa-npg-sdk-sync-deploy-pipelines.yml
+++ b/.devops/pagopa-npg-sdk-sync-deploy-pipelines.yml
@@ -1,0 +1,75 @@
+# Azure DevOps pipeline to sync NPG SDK from Nexi to checkout CDN storage.
+# Runs hourly: downloads the SDK, computes its SHA-384 hash, and verifies it
+# against NPG's source-of-truth hash (fetched from the payment-methods-handler
+# integrity endpoint via APIM). Only on a match are the SDK and its integrity
+# JSON published to $web/npg/sdk/ on each environment's storage account; on a
+# mismatch the pipeline fails and the last-known-good stays served.
+
+trigger: none
+pr: none
+
+schedules:
+  - cron: "0 * * * *"
+    displayName: "Sync NPG SDK hourly"
+    branches:
+      include:
+        - main
+    always: true
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+stages:
+  - stage: Sync_DEV
+    dependsOn: []
+    jobs:
+      - job: sync_npg_sdk
+        displayName: 'Sync NPG SDK to DEV'
+        steps:
+          - template: azure-templates/sync-npg-sdk-steps.yml
+            parameters:
+              npg_origin: 'https://stg-ta.nexigroup.com'
+              integrity_endpoint: 'https://api.dev.platform.pagopa.it/checkout/npg/sdk/v1/integrity'
+              storage_account: 'pagopadweucheckoutcdnsa'
+              cdn_rg: 'pagopa-d-checkout-fe-rg'
+              cdn_profile: 'pagopa-d-weu-checkout-cdn-profile'
+              cdn_endpoint: 'pagopa-d-weu-checkout-cdn-endpoint'
+              service_connection: 'DEV-PAGOPA-SERVICE-CONN'
+              app_insights_name: 'pagopa-d-appinsights'
+              app_insights_rg: 'pagopa-d-monitor-rg'
+
+  - stage: Sync_UAT
+    dependsOn: []
+    jobs:
+      - job: sync_npg_sdk
+        displayName: 'Sync NPG SDK to UAT'
+        steps:
+          - template: azure-templates/sync-npg-sdk-steps.yml
+            parameters:
+              npg_origin: 'https://stg-ta.nexigroup.com'
+              integrity_endpoint: 'https://api.uat.platform.pagopa.it/checkout/npg/sdk/v1/integrity'
+              storage_account: 'pagopauweucheckoutcdnsa'
+              cdn_rg: 'pagopa-u-checkout-fe-rg'
+              cdn_profile: 'pagopa-u-weu-checkout-cdn-profile'
+              cdn_endpoint: 'pagopa-u-weu-checkout-cdn-endpoint'
+              service_connection: 'UAT-PAGOPA-SERVICE-CONN'
+              app_insights_name: 'pagopa-u-appinsights'
+              app_insights_rg: 'pagopa-u-monitor-rg'
+
+  - stage: Sync_PROD
+    dependsOn: []
+    jobs:
+      - job: sync_npg_sdk
+        displayName: 'Sync NPG SDK to PROD'
+        steps:
+          - template: azure-templates/sync-npg-sdk-steps.yml
+            parameters:
+              npg_origin: 'https://xpay.nexigroup.com'
+              integrity_endpoint: 'https://api.platform.pagopa.it/checkout/npg/sdk/v1/integrity'
+              storage_account: 'pagopapweucheckoutcdnsa'
+              cdn_rg: 'pagopa-p-checkout-fe-rg'
+              cdn_profile: 'pagopa-p-weu-checkout-cdn-profile'
+              cdn_endpoint: 'pagopa-p-weu-checkout-cdn-endpoint'
+              service_connection: 'PROD-PAGOPA-SERVICE-CONN'
+              app_insights_name: 'pagopa-p-appinsights'
+              app_insights_rg: 'pagopa-p-monitor-rg'


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

- add scheduled (hourly) NPG SDK sync pipeline `pagopa-npg-sdk-sync-deploy-pipelines.yml` with `Sync_DEV`/`Sync_UAT`/`Sync_PROD` stages
- add `azure-templates/sync-npg-sdk-steps.yml`: download the SDK from NPG, verify its SHA-384 against the payment-methods-handler `/integrity` endpoint, publish the SDK + integrity JSON to `$web/npg/sdk/`, purge the CDN, and emit an App Insights heartbeat on success
- exclude `npg/sdk` from the checkout-fe CDN deploy (`az storage blob sync --exclude-path npg/sdk`) on DEV/UAT/PROD so synced files are not overwritten by the frontend deploy

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Part of PIDM-500 (self-hosting the NPG SDK with SRI verification). This PR ships only the supply side - publishing the SDK and its integrity hash to each environment's storage - leaving the files unconsumed: the frontend keeps loading the SDK from Nexi until consumption is activated separately (https://github.com/pagopa/pagopa-checkout-fe/pull/658). This lets the full pipeline be verified up to PROD without changing runtime behaviour.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- DEV: full run validated end-to-end in prior runs - download → SHA-384 verify against `/integrity` → publish to `$web/npg/sdk/` → CDN purge → App Insights heartbeat (`NpgSdkSyncSuccess`, `itemsAccepted=1`)
- UAT/PROD: pending their prerequisites (handler `/integrity` + APIM live, and service-connection authorization via https://github.com/pagopa/pagopa-azure-devops/pull/477)

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
