### PR TITLE
[PIDM-2241] fix bin value in calculateFees

### DIFF
--- a/src/features/payment/components/PaymentChoice/PaymentChoice.tsx
+++ b/src/features/payment/components/PaymentChoice/PaymentChoice.tsx
@@ -35,6 +35,7 @@ import { PaymentMethodRoutes } from "../../../../routes/models/paymentMethodRout
 import { getFees, recaptchaTransaction } from "../../../../utils/api/helper";
 import {
   SessionItems,
+  clearSessionItem,
   getReCaptchaKey,
   getSessionItem,
   setSessionItem,
@@ -195,6 +196,7 @@ export function PaymentChoice(props: {
   const handleClickOnMethod = async (method: PaymentInstrumentsType) => {
     if (!loading) {
       const { paymentTypeCode, id: paymentMethodId } = method;
+      clearSessionItem(SessionItems.sessionPaymentMethod);
       setSessionItem(SessionItems.paymentMethodInfo, {
         title: getMethodDescriptionForCurrentLanguage(method),
         asset: method.asset || "",
@@ -216,6 +218,7 @@ export function PaymentChoice(props: {
 
   // eslint-disable-next-line no-console
   const handleClickOnMethodWallet = async (method: WalletInfo) => {
+    clearSessionItem(SessionItems.sessionPaymentMethod);
     setSessionItem(SessionItems.paymentMethodInfo, {
       title: getDescriptionWallet(method),
       asset: method.paymentMethodAsset || "",

--- a/src/features/payment/components/PaymentChoice/__tests__/PaymentChoice.test.tsx
+++ b/src/features/payment/components/PaymentChoice/__tests__/PaymentChoice.test.tsx
@@ -15,6 +15,7 @@ import { PaymentInstrumentsType } from "../../../models/paymentModel";
 import { PaymentMethodStatusEnum } from "../../../../../../generated/definitions/payment-ecommerce/PaymentMethodStatus";
 import "whatwg-fetch";
 import * as helperModule from "../../../../../utils/api/helper";
+import * as sessionStorageModule from "../../../../../utils/storage/sessionStorage";
 import * as transactionsErrorHelperModule from "../../../../../utils/api/transactionsErrorHelper";
 import { MethodManagementEnum } from "../../../../../../generated/definitions/payment-ecommerce-v2/PaymentMethodResponse";
 import { WalletInfo } from "../../../../../../generated/definitions/checkout-wallets-v1/WalletInfo";
@@ -64,6 +65,7 @@ jest.mock("../../../../../utils/storage/sessionStorage", () => ({
   SessionItems: {
     paymentMethodInfo: "paymentMethodInfo",
     paymentMethod: "paymentMethod",
+    sessionPaymentMethod: "sessionPayment",
     orderId: "orderId",
     correlationId: "correlationId",
     enablePspPage: "enablePspPage",
@@ -71,8 +73,11 @@ jest.mock("../../../../../utils/storage/sessionStorage", () => ({
   },
   getSessionItem: jest.fn(),
   setSessionItem: jest.fn(),
+  clearSessionItem: jest.fn(),
   getReCaptchaKey: jest.fn(() => "mock-recaptcha-key"),
 }));
+const mockedClearSessionItem =
+  sessionStorageModule.clearSessionItem as jest.Mock;
 
 // Mock navigate function
 const mockNavigate = jest.fn();
@@ -602,6 +607,11 @@ describe("PaymentChoice", () => {
 
     // Should navigate to the card payment route
     expect(mockNavigate).toHaveBeenCalledWith("/card-payment");
+
+    // Should drop any bin left over from a previously selected card
+    expect(mockedClearSessionItem).toHaveBeenCalledWith(
+      sessionStorageModule.SessionItems.sessionPaymentMethod
+    );
   });
 
   it("should handle non-credit card payment method click", async () => {
@@ -635,6 +645,11 @@ describe("PaymentChoice", () => {
 
     // Click on the PayPal payment method
     fireEvent.click(getByText("PayPal"));
+
+    // Should drop any bin left over from a previously selected card
+    expect(mockedClearSessionItem).toHaveBeenCalledWith(
+      sessionStorageModule.SessionItems.sessionPaymentMethod
+    );
 
     expect(mockedRecaptchaTransaction).toHaveBeenCalled();
 
@@ -924,6 +939,11 @@ describe("PaymentChoice", () => {
     });
 
     fireEvent.click(getByText(cardWalletDescription));
+
+    // Should drop any bin left over from a previously selected card
+    expect(mockedClearSessionItem).toHaveBeenCalledWith(
+      sessionStorageModule.SessionItems.sessionPaymentMethod
+    );
 
     expect(mockedRecaptchaTransaction).toHaveBeenCalledTimes(1);
 

--- a/src/routes/__tests__/PaymentChoicePage.test.tsx
+++ b/src/routes/__tests__/PaymentChoicePage.test.tsx
@@ -167,6 +167,7 @@ jest.mock("../../utils/api/client", () => ({
 jest.mock("../../utils/storage/sessionStorage", () => ({
   getSessionItem: jest.fn(),
   setSessionItem: jest.fn(),
+  clearSessionItem: jest.fn(),
   getReCaptchaKey: jest.fn(),
   getRptIdsFromSession: jest.fn(),
   SessionItems: {
@@ -181,7 +182,7 @@ jest.mock("../../utils/storage/sessionStorage", () => ({
     paymentMethod: "paymentMethod",
     orderId: "orderId",
     correlationId: "correlationId",
-    sessionPayment: "sessionPayment",
+    sessionPaymentMethod: "sessionPayment",
     transaction: "transaction",
     enableWallet: "enableWallet",
     enablePaymentMethodsHandler: "enablePaymentMethodsHandler",


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- added `clearSessionItem(SessionItems.sessionPaymentMethod)` for fix bug
<!--- Describe your changes in detail -->

#### Motivation and Context
When the user changes payment method, if had previously selected "cards" and reached the PSP selection stage, the BIN is saved in the session, then, when payment method is modified, the BIN would still be sent in the subsequent request, even if "cards" were not selected.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
